### PR TITLE
#155922704 Lock screen orientation to portrait

### DIFF
--- a/app/src/androidTest/java/com/andela/art/root/AppTest.java
+++ b/app/src/androidTest/java/com/andela/art/root/AppTest.java
@@ -1,0 +1,52 @@
+package com.andela.art.root;
+
+import android.content.res.Configuration;
+import android.os.RemoteException;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.test.uiautomator.UiDevice;
+
+import com.andela.art.login.LoginActivity;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by Jeffkungu on 14/03/2018.
+ */
+@RunWith(AndroidJUnit4.class)
+public class AppTest {
+
+    UiDevice device = UiDevice.getInstance(getInstrumentation());
+
+    @Rule
+    public ActivityTestRule<LoginActivity> loginActivityRule =
+            new ActivityTestRule<>(LoginActivity.class, true, false);
+
+    @Test
+    public void deviceInLandscape_ActivityLaunchesInPortrait() throws RemoteException {
+        device.setOrientationLeft();
+
+        loginActivityRule.launchActivity(null);
+
+        assertEquals(Configuration.ORIENTATION_PORTRAIT, getActivityOrientation());
+    }
+
+    @Test
+    public void changeDeviceToLandscape_OrientationRemainsPortrait() throws RemoteException {
+        loginActivityRule.launchActivity(null);
+
+        device.setOrientationLeft();
+
+        Assert.assertEquals(Configuration.ORIENTATION_PORTRAIT, getActivityOrientation());
+    }
+
+    private int getActivityOrientation() {
+        return loginActivityRule.getActivity().getResources().getConfiguration().orientation;
+    }
+}

--- a/app/src/androidTest/java/com/andela/art/root/AppTest.java
+++ b/app/src/androidTest/java/com/andela/art/root/AppTest.java
@@ -28,6 +28,11 @@ public class AppTest {
     public ActivityTestRule<LoginActivity> loginActivityRule =
             new ActivityTestRule<>(LoginActivity.class, true, false);
 
+    /**
+     * Tests that an activity launches in portrait even if the device is in landscape mode.
+     *
+     * @throws RemoteException if an error occurs.
+     */
     @Test
     public void deviceInLandscape_ActivityLaunchesInPortrait() throws RemoteException {
         device.setOrientationLeft();
@@ -37,6 +42,12 @@ public class AppTest {
         assertEquals(Configuration.ORIENTATION_PORTRAIT, getActivityOrientation());
     }
 
+    /**
+     * Tests that an activity remains in portrait even if the device's orientation is altered
+     * to landscape mode.
+     *
+     * @throws RemoteException if an error occurs.
+     */
     @Test
     public void changeDeviceToLandscape_OrientationRemainsPortrait() throws RemoteException {
         loginActivityRule.launchActivity(null);
@@ -46,6 +57,11 @@ public class AppTest {
         Assert.assertEquals(Configuration.ORIENTATION_PORTRAIT, getActivityOrientation());
     }
 
+    /**
+     * Get activity orientation.
+     *
+     * @return orientation - return the orientation of the activity under test.
+     */
     private int getActivityOrientation() {
         return loginActivityRule.getActivity().getResources().getConfiguration().orientation;
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:name=".root.App"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">

--- a/app/src/main/java/com/andela/art/login/LoginActivity.java
+++ b/app/src/main/java/com/andela/art/login/LoginActivity.java
@@ -2,7 +2,6 @@ package com.andela.art.login;
 
 import android.app.ProgressDialog;
 import android.content.Intent;
-import android.content.pm.ActivityInfo;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -64,7 +63,6 @@ public class LoginActivity extends AppCompatActivity implements LoginActivityMVP
         w.setFlags(
                 WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
                 WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
-        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         ActivityLoginBinding activityLoginBinding = DataBindingUtil
                 .setContentView(this, R.layout.activity_login);
         activityLoginBinding.googleSignInButton.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/com/andela/art/root/App.java
+++ b/app/src/main/java/com/andela/art/root/App.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.pm.ActivityInfo;
 import android.os.Bundle;
-import android.util.Log;
 
 import com.andela.art.login.LoginModule;
 
@@ -28,37 +27,36 @@ public class App extends Application {
             @Override
             public void onActivityCreated(Activity activity, Bundle bundle) {
                 activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-                Log.i("tests", "2. setting activities orientation");
             }
 
             @Override
             public void onActivityStarted(Activity activity) {
-
+                // To do on activity started
             }
 
             @Override
             public void onActivityResumed(Activity activity) {
-
+                // To do on activity resumed
             }
 
             @Override
             public void onActivityPaused(Activity activity) {
-
+                // To do on activity paused
             }
 
             @Override
             public void onActivityStopped(Activity activity) {
-
+                // To do on activity stopped
             }
 
             @Override
             public void onActivitySaveInstanceState(Activity activity, Bundle bundle) {
-
+                // To do on activity saved instance state
             }
 
             @Override
             public void onActivityDestroyed(Activity activity) {
-
+                // To do on activity destroyed
             }
         });
     }

--- a/app/src/main/java/com/andela/art/root/App.java
+++ b/app/src/main/java/com/andela/art/root/App.java
@@ -1,6 +1,10 @@
 package com.andela.art.root;
 
+import android.app.Activity;
 import android.app.Application;
+import android.content.pm.ActivityInfo;
+import android.os.Bundle;
+import android.util.Log;
 
 import com.andela.art.login.LoginModule;
 
@@ -20,6 +24,43 @@ public class App extends Application {
                 .loginModule(new LoginModule())
                 .build();
 
+        registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacks() {
+            @Override
+            public void onActivityCreated(Activity activity, Bundle bundle) {
+                activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+                Log.i("tests", "2. setting activities orientation");
+            }
+
+            @Override
+            public void onActivityStarted(Activity activity) {
+
+            }
+
+            @Override
+            public void onActivityResumed(Activity activity) {
+
+            }
+
+            @Override
+            public void onActivityPaused(Activity activity) {
+
+            }
+
+            @Override
+            public void onActivityStopped(Activity activity) {
+
+            }
+
+            @Override
+            public void onActivitySaveInstanceState(Activity activity, Bundle bundle) {
+
+            }
+
+            @Override
+            public void onActivityDestroyed(Activity activity) {
+
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?
Ensures that the screen orientation for all activities is locked to portrait
## Description of Task to be completed?
- Add tests to check activity orientation
- Remove the portrait screen lock logic previously added to *each* activity 
- Add logic to lock the screen orientation to portrait for all activities from one point
## How should this be manually tested?
- Run the AppTest test file
- Launch the App on a device and try to change the device's orientation to confirm that this doesn't alter the orientation of any of this App's activities from portrait.
## What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/155922704
## Screenshot
App showing in portrait with device in landscape mode
![image](https://81bac6a8-a-62cb3a1a-s-sites.googlegroups.com/site/thebadmanstestsite/testing/appInPortrait_deviceInLandscape.png?attachauth=ANoY7crPtX7StYcPVcfw-8cfaDJMAx2BcYlITdHq7Fb_BGUIfTbl5hVDdqPWVzLZnmpPxhFwfTVWpC2WDqsMcMrv6-naw1yiqBdJzLGjGm4ude5SuAGYFk1osj8lBivul2oBKVLVO3knAa_kxKaazTHPwNwJ0MhjUs4In9Yd0V53rPUiYSLlvB1nCvoxAM4g5JF506fTKArUM_gmE-3YGwEN4xCq6Ut9zIYKNggtPtnEj4NHnUjEF0GJ4XOl9pCbZqHJgKJgrb0w&attredirects=0)