### PR TITLE
#155850808 Separate code analysis tools to run concurrently in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
       
       # Storing reports
       - store_artifacts:
-          path: ~/repo/app/build/reports
+          path: ~/repo/app/build
       
       # Sending notification
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
       
       # Storing reports
       - store_artifacts:
-          path: ~/repo/app/build
+          path: ~/repo/app/build/outputs
       
       # Sending notification
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ default: &defaults
 
 version: 2
 jobs:
-  lint:
+  android_lint:
     <<: *defaults
     steps:
       - checkout
@@ -31,11 +31,129 @@ jobs:
       - run:
           name: Running quality checks
           command: |
-            echo "Run lint, findbugs, pmd, checkstyle"
+            echo "Run android lint"
             cd ~/repo
             ./gradlew lint
+      
+      # Storing reports
+      - store_artifacts:
+          path: ~/repo/app/build/reports
+      
+      # Sending notification
+      - run:
+          name: Notifying slack channel (succeeded)
+          when: on_success
+          command: |
+            bash ~/repo/.circleci/notify_slack.sh
+      - run:
+          name: Notifying slack channel (failed)
+          when: on_fail
+          command: |
+            bash ~/repo/.circleci/notify_slack_fail.sh
+
+  findbugs_lint:
+    <<: *defaults
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "build.gradle" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run: ./gradlew androidDependencies
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: v1-dependencies-{{ checksum "build.gradle" }}
+      
+      # Running static analysis tools
+      - run:
+          name: Running quality checks
+          command: |
+            echo "Run findbugs"
+            cd ~/repo
+            ./gradlew assemble
             ./gradlew findbugs
+      
+      # Storing reports
+      - store_artifacts:
+          path: ~/repo/app/build/reports
+      
+      # Sending notification
+      - run:
+          name: Notifying slack channel (succeeded)
+          when: on_success
+          command: |
+            bash ~/repo/.circleci/notify_slack.sh
+      - run:
+          name: Notifying slack channel (failed)
+          when: on_fail
+          command: |
+            bash ~/repo/.circleci/notify_slack_fail.sh
+
+  pmd_lint:
+    <<: *defaults
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "build.gradle" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run: ./gradlew androidDependencies
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: v1-dependencies-{{ checksum "build.gradle" }}
+      
+      # Running static analysis tools
+      - run:
+          name: Running quality checks
+          command: |
+            echo "Run PMD"
+            cd ~/repo
             ./gradlew pmd
+      
+      # Storing reports
+      - store_artifacts:
+          path: ~/repo/app/build/reports
+      
+      # Sending notification
+      - run:
+          name: Notifying slack channel (succeeded)
+          when: on_success
+          command: |
+            bash ~/repo/.circleci/notify_slack.sh
+      - run:
+          name: Notifying slack channel (failed)
+          when: on_fail
+          command: |
+            bash ~/repo/.circleci/notify_slack_fail.sh
+
+  checkstyle_lint:
+    <<: *defaults
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "build.gradle" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run: ./gradlew androidDependencies
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: v1-dependencies-{{ checksum "build.gradle" }}
+      
+      # Running static analysis tools
+      - run:
+          name: Running quality checks
+          command: |
+            echo "Run checkstyle"
+            cd ~/repo
             ./gradlew checkstyle
       
       # Storing reports
@@ -252,10 +370,16 @@ workflows:
   version: 2
   lint_test_and_deployment:
     jobs:
-      - lint
+      - android_lint
+      - findbugs_lint
+      - pmd_lint
+      - checkstyle_lint
       - test:
           requires:
-            - lint
+            - android_lint
+            - findbugs_lint
+            - pmd_lint
+            - checkstyle_lint
       - deploy_test_build:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
       
       # Storing reports
       - store_artifacts:
-          path: ~/repo/app/build/reports
+          path: ~/repo/app/build
       
       # Sending notification
       - run:

--- a/.circleci/notify_slack.sh
+++ b/.circleci/notify_slack.sh
@@ -60,12 +60,20 @@ declare_env_variables() {
     JOB_NAME="Test Phase Passed! :smiley:"
 
     # Sorting through the artifact urls to get only the unit test and integration test reports
-
-    CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
-/g' |  grep 'index\.html')"
-    INTEGRATION_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+    DEBUG_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'testDebugUnitTest\/index\.html')"
+    RELEASE_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'testReleaseUnitTest\/index\.html')"
+    JACOCO_DEBUG_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'jacocoTestDebugUnitTestReport\/html\/index\.html')"
+    JACOCO_RELEASE_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'jacocoTestReleaseUnitTestReport\/html\/index\.html')"
+    INTEGRATION_TEST_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
 /g' |  grep 'AVD')"
-    CIRCLE_ARTIFACTS_MESSAGE="Get the test reports here: \n ${CIRCLE_REPORT_ARTIFACTS} \n ${INTEGRATION_REPORT}"
+    CIRCLE_ARTIFACTS_MESSAGE="Get the test reports here:
+    \n Unit Test Reports <${DEBUG_REPORT}|Debug> | <${RELEASE_REPORT}|Release>
+    \n Jacoco Unit Test Reports <${JACOCO_DEBUG_REPORT}|Debug> | <${JACOCO_Release_REPORT}|Release>
+    \n <${INTEGRATION_TEST_REPORT}|Android Virtual Device (AVD) Test Report>"
 
   elif [ "$CIRCLE_JOB" == 'deploy_test_build' ]; then
     JOB_NAME="Deploy Test Build Succeeded :rocket:"

--- a/.circleci/notify_slack.sh
+++ b/.circleci/notify_slack.sh
@@ -20,14 +20,41 @@ declare_env_variables() {
 
   # Assigning slack messages based on the CircleCI job name
 
-  if [ "$CIRCLE_JOB" == 'lint' ]; then
-    JOB_NAME="Lint Phase Passed! :smirk_cat:"
+  if [ "$CIRCLE_JOB" == 'android_lint' ]; then
+    JOB_NAME="Android Lint Phase Passed! :smirk_cat:"
 
-    # Sorting through the artifact urls to get only the lint reports
+    # Sorting through the artifact urls to get only the android lint reports
 
     CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
 /g' |  grep '\.html')"
-    CIRCLE_ARTIFACTS_MESSAGE="Get the lint reports here: \n ${CIRCLE_REPORT_ARTIFACTS}"
+    CIRCLE_ARTIFACTS_MESSAGE="Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
+
+  elif [ "$CIRCLE_JOB" == 'findbugs_lint' ]; then
+    JOB_NAME="Findbugs Lint Phase Passed! :smirk_cat:"
+
+    # Sorting through the artifact urls to get only the findbugs lint reports
+
+    CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep '\.html')"
+    CIRCLE_ARTIFACTS_MESSAGE="Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
+
+  elif [ "$CIRCLE_JOB" == 'pmd_lint' ]; then
+    JOB_NAME="PMD Lint Phase Passed! :smirk_cat:"
+
+    # Sorting through the artifact urls to get only the PMD lint reports
+
+    CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep '\.html')"
+    CIRCLE_ARTIFACTS_MESSAGE="Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
+
+  elif [ "$CIRCLE_JOB" == 'checkstyle_lint' ]; then
+    JOB_NAME="Checkstyle Lint Phase Passed! :smirk_cat:"
+
+    # Sorting through the artifact urls to get only the findbugs lint reports
+
+    CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep '\.html')"
+    CIRCLE_ARTIFACTS_MESSAGE="Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
 
   elif [ "$CIRCLE_JOB" == 'test' ]; then
     JOB_NAME="Test Phase Passed! :smiley:"

--- a/.circleci/notify_slack.sh
+++ b/.circleci/notify_slack.sh
@@ -27,7 +27,7 @@ declare_env_variables() {
 
     CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
 /g' |  grep '\.html')"
-    CIRCLE_ARTIFACTS_MESSAGE="Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
+    CIRCLE_ARTIFACTS_MESSAGE="Get the report <${CIRCLE_REPORT_ARTIFACTS}|here>"
 
   elif [ "$CIRCLE_JOB" == 'findbugs_lint' ]; then
     JOB_NAME="Findbugs Lint Phase Passed! :smirk_cat:"
@@ -35,8 +35,8 @@ declare_env_variables() {
     # Sorting through the artifact urls to get only the findbugs lint reports
 
     CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
-/g' |  grep '\.html')"
-    CIRCLE_ARTIFACTS_MESSAGE="Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
+/g' |  grep 'findbugs\.html')"
+    CIRCLE_ARTIFACTS_MESSAGE="Get the report <${CIRCLE_REPORT_ARTIFACTS}|here>"
 
   elif [ "$CIRCLE_JOB" == 'pmd_lint' ]; then
     JOB_NAME="PMD Lint Phase Passed! :smirk_cat:"
@@ -45,7 +45,7 @@ declare_env_variables() {
 
     CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
 /g' |  grep '\.html')"
-    CIRCLE_ARTIFACTS_MESSAGE="Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
+    CIRCLE_ARTIFACTS_MESSAGE="Get the report <${CIRCLE_REPORT_ARTIFACTS}|here>"
 
   elif [ "$CIRCLE_JOB" == 'checkstyle_lint' ]; then
     JOB_NAME="Checkstyle Lint Phase Passed! :smirk_cat:"
@@ -54,7 +54,7 @@ declare_env_variables() {
 
     CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
 /g' |  grep '\.html')"
-    CIRCLE_ARTIFACTS_MESSAGE="Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
+    CIRCLE_ARTIFACTS_MESSAGE="Get the report <${CIRCLE_REPORT_ARTIFACTS}|here>"
 
   elif [ "$CIRCLE_JOB" == 'test' ]; then
     JOB_NAME="Test Phase Passed! :smiley:"

--- a/.circleci/notify_slack.sh
+++ b/.circleci/notify_slack.sh
@@ -72,7 +72,7 @@ declare_env_variables() {
 /g' |  grep 'AVD')"
     CIRCLE_ARTIFACTS_MESSAGE="Get the test reports here:
     \n Unit Test Reports <${DEBUG_REPORT}|Debug> | <${RELEASE_REPORT}|Release>
-    \n Jacoco Unit Test Reports <${JACOCO_DEBUG_REPORT}|Debug> | <${JACOCO_Release_REPORT}|Release>
+    \n Jacoco Unit Test Reports <${JACOCO_DEBUG_REPORT}|Debug> | <${JACOCO_RELEASE_REPORT}|Release>
     \n <${INTEGRATION_TEST_REPORT}|Android Virtual Device (AVD) Test Report>"
 
   elif [ "$CIRCLE_JOB" == 'deploy_test_build' ]; then

--- a/.circleci/notify_slack_fail.sh
+++ b/.circleci/notify_slack_fail.sh
@@ -20,13 +20,37 @@ declare_env_variables() {
 
   # Assigning slack messages based on the CircleCI job name
 
-  if [ "$CIRCLE_JOB" == 'lint' ]; then
+  if [ "$CIRCLE_JOB" == 'android_lint' ]; then
 
-    # Sorting through the artifact urls to get only the lint reports
+    # Sorting through the artifact urls to get only the android lint report
 
     CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
 /g' |  grep '\.html')"
-    CIRCLE_ARTIFACTS_MESSAGE="Lint Phase Failed! :crying_cat_face: \n Get the lint reports here: \n ${CIRCLE_REPORT_ARTIFACTS}"
+    CIRCLE_ARTIFACTS_MESSAGE="Android Lint Phase Failed! :crying_cat_face: \n Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
+
+  elif [ "$CIRCLE_JOB" == 'fingbugs_lint' ]; then
+
+    # Sorting through the artifact urls to get only the findbugs lint report
+
+    CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep '\.html')"
+    CIRCLE_ARTIFACTS_MESSAGE="Findbugs Lint Phase Failed! :crying_cat_face: \n Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
+
+  elif [ "$CIRCLE_JOB" == 'pmd_lint' ]; then
+
+    # Sorting through the artifact urls to get only the PMD lint report
+
+    CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep '\.html')"
+    CIRCLE_ARTIFACTS_MESSAGE="PMD Lint Phase Failed! :crying_cat_face: \n Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
+
+  elif [ "$CIRCLE_JOB" == 'checkstyle_lint' ]; then
+
+    # Sorting through the artifact urls to get only the checkstyle lint report
+
+    CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep '\.html')"
+    CIRCLE_ARTIFACTS_MESSAGE="Checkstyle Lint Phase Failed! :crying_cat_face: \n Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
 
   elif [ "$CIRCLE_JOB" == 'test' ]; then
 

--- a/.circleci/notify_slack_fail.sh
+++ b/.circleci/notify_slack_fail.sh
@@ -28,7 +28,7 @@ declare_env_variables() {
 /g' |  grep '\.html')"
     CIRCLE_ARTIFACTS_MESSAGE="Android Lint Phase Failed! :crying_cat_face: \n Get the report <${CIRCLE_REPORT_ARTIFACTS}|here>"
 
-  elif [ "$CIRCLE_JOB" == 'fingbugs_lint' ]; then
+  elif [ "$CIRCLE_JOB" == 'findbugs_lint' ]; then
 
     # Sorting through the artifact urls to get only the findbugs lint report
 

--- a/.circleci/notify_slack_fail.sh
+++ b/.circleci/notify_slack_fail.sh
@@ -56,11 +56,20 @@ declare_env_variables() {
 
     # Sorting through the artifact urls to get only the unit test and integration test reports
 
-    CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
-/g' |  grep 'index\.html')"
-    INTEGRATION_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+    DEBUG_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'testDebugUnitTest\/index\.html')"
+    RELEASE_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'testReleaseUnitTest\/index\.html')"
+    JACOCO_DEBUG_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'jacocoTestDebugUnitTestReport\/html\/index\.html')"
+    JACOCO_RELEASE_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'jacocoTestReleaseUnitTestReport\/html\/index\.html')"
+    INTEGRATION_TEST_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
 /g' |  grep 'AVD')"
-    CIRCLE_ARTIFACTS_MESSAGE="Test Phase Failed! :scream: \n Get the test reports here: \n ${CIRCLE_REPORT_ARTIFACTS} \n ${INTEGRATION_REPORT}"
+    CIRCLE_ARTIFACTS_MESSAGE="Test Phase Failed! :scream: \n Get the test reports here:
+    \n Unit Test Reports <${DEBUG_REPORT}|Debug> | <${RELEASE_REPORT}|Release>
+    \n Jacoco Unit Test Reports <${JACOCO_DEBUG_REPORT}|Debug> | <${JACOCO_Release_REPORT}|Release>
+    \n <${INTEGRATION_TEST_REPORT}|Android Virtual Device (AVD) Test Report>"
 
   elif [ "$CIRCLE_JOB" == 'deploy_test_build' ]; then
     CIRCLE_ARTIFACTS_MESSAGE="Test Build for Deployment Failed! :scream: \n Get the build reports here:  \n ${CIRCLE_REPORT_ARTIFACTS}"

--- a/.circleci/notify_slack_fail.sh
+++ b/.circleci/notify_slack_fail.sh
@@ -68,7 +68,7 @@ declare_env_variables() {
 /g' |  grep 'AVD')"
     CIRCLE_ARTIFACTS_MESSAGE="Test Phase Failed! :scream: \n Get the test reports here:
     \n Unit Test Reports <${DEBUG_REPORT}|Debug> | <${RELEASE_REPORT}|Release>
-    \n Jacoco Unit Test Reports <${JACOCO_DEBUG_REPORT}|Debug> | <${JACOCO_Release_REPORT}|Release>
+    \n Jacoco Unit Test Reports <${JACOCO_DEBUG_REPORT}|Debug> | <${JACOCO_RELEASE_REPORT}|Release>
     \n <${INTEGRATION_TEST_REPORT}|Android Virtual Device (AVD) Test Report>"
 
   elif [ "$CIRCLE_JOB" == 'deploy_test_build' ]; then

--- a/.circleci/notify_slack_fail.sh
+++ b/.circleci/notify_slack_fail.sh
@@ -26,15 +26,15 @@ declare_env_variables() {
 
     CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
 /g' |  grep '\.html')"
-    CIRCLE_ARTIFACTS_MESSAGE="Android Lint Phase Failed! :crying_cat_face: \n Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
+    CIRCLE_ARTIFACTS_MESSAGE="Android Lint Phase Failed! :crying_cat_face: \n Get the report <${CIRCLE_REPORT_ARTIFACTS}|here>"
 
   elif [ "$CIRCLE_JOB" == 'fingbugs_lint' ]; then
 
     # Sorting through the artifact urls to get only the findbugs lint report
 
     CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
-/g' |  grep '\.html')"
-    CIRCLE_ARTIFACTS_MESSAGE="Findbugs Lint Phase Failed! :crying_cat_face: \n Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
+/g' |  grep 'findbugs\.html')"
+    CIRCLE_ARTIFACTS_MESSAGE="Findbugs Lint Phase Failed! :crying_cat_face: \n Get the report <${CIRCLE_REPORT_ARTIFACTS}|here>"
 
   elif [ "$CIRCLE_JOB" == 'pmd_lint' ]; then
 
@@ -42,7 +42,7 @@ declare_env_variables() {
 
     CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
 /g' |  grep '\.html')"
-    CIRCLE_ARTIFACTS_MESSAGE="PMD Lint Phase Failed! :crying_cat_face: \n Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
+    CIRCLE_ARTIFACTS_MESSAGE="PMD Lint Phase Failed! :crying_cat_face: \n Get the report <${CIRCLE_REPORT_ARTIFACTS}|here>"
 
   elif [ "$CIRCLE_JOB" == 'checkstyle_lint' ]; then
 
@@ -50,7 +50,7 @@ declare_env_variables() {
 
     CIRCLE_REPORT_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
 /g' |  grep '\.html')"
-    CIRCLE_ARTIFACTS_MESSAGE="Checkstyle Lint Phase Failed! :crying_cat_face: \n Get the report <here|${CIRCLE_REPORT_ARTIFACTS}>"
+    CIRCLE_ARTIFACTS_MESSAGE="Checkstyle Lint Phase Failed! :crying_cat_face: \n Get the report <${CIRCLE_REPORT_ARTIFACTS}|here>"
 
   elif [ "$CIRCLE_JOB" == 'test' ]; then
 


### PR DESCRIPTION
#### What does this PR do?
Modify the config files for CircleCI to run each of the code analysis tools in their own environment concurrently.
#### Description of Task to be completed?
_Currently:_
The pipeline has 3 jobs maximum; lint, test and deploy. The lint job executes static code analysis with four tools: findbugs, checkstyle, pmd and android lint.
If one of these tools flags an error, the job will fail and the lint commands that follow will not be executed.

_Expected:_
Set up the workflow so that all four linting commands are executed simultaneously and the test job only begins when they all pass. Additionally, set up the slack notifications to indicate which specific lint processes have failed.
This way the developers do not have to resolve code quality errors one tool at a time.
#### How should this be manually tested?
Pushing a commit to the remote repository will trigger a build and send notifications when they have either passed or failed.
The unit tests and integration tests will only run if the code analysis tools report zero violations.
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/155850808
#### Screenshots
<img width="515" alt="screen shot 2018-03-19 at 14 42 42" src="https://user-images.githubusercontent.com/31277260/37593730-0abde69e-2b84-11e8-8e65-0d9546cc50a4.png">
<img width="674" alt="screen shot 2018-03-19 at 16 03 30" src="https://user-images.githubusercontent.com/31277260/37597011-1eac73ae-2b8f-11e8-8f51-164e4eed75ce.png">
<img width="563" alt="screen shot 2018-03-19 at 16 04 03" src="https://user-images.githubusercontent.com/31277260/37597037-2f8838fc-2b8f-11e8-9ab7-eb267fad9c9f.png">
