### PR TITLE
#156266393 Add settings page

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test:rules:1.0.1'
     androidTestImplementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
     androidTestImplementation 'com.android.support.test.espresso:espresso-contrib:3.0.1'
+    androidTestCompile "com.android.support.test.espresso:espresso-intents:3.0.1"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/androidTest/java/com/andela/art/settings/SettingsTest.java
+++ b/app/src/androidTest/java/com/andela/art/settings/SettingsTest.java
@@ -1,11 +1,11 @@
-package com.andela.art.securitydashboard;
+package com.andela.art.settings;
 
 import android.support.test.espresso.intent.Intents;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.andela.art.R;
-import com.andela.art.settings.SettingsActivity;
+import com.andela.art.securitydashboard.SecurityDashboardActivity;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -19,49 +19,33 @@ import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.intent.Intents.intended;
 import static android.support.test.espresso.intent.matcher.IntentMatchers.hasComponent;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 /**
- * Tests for the security dashboard.
+ * Tests for the settings activity.
  */
 @RunWith(AndroidJUnit4.class)
-public class SecurityDashboardTest {
+public class SettingsTest {
 
     @Rule
     public ActivityTestRule<SecurityDashboardActivity> securityDashboardActivityTestRule =
             new ActivityTestRule<>(SecurityDashboardActivity.class);
 
     /**
-     * Tests that the toolbar is shown on the security dashboard.
+     * Tests that clicking the tool bar home button on the settings activity returns user to
+     * the security dashboard activity.
      */
     @Test
-    public void toolBarIsRenderedInDashboardActivity() {
-        onView(withId(R.id.mToolBar)).check(matches(isDisplayed()));
-    }
-
-    /**
-     * Tests that the menu is shown on the security dashboard in the toolbar by checking the
-     * presence of the settings menu item.
-     */
-    @Test
-    public void menuIsRenderedInDashboardActivity() {
-        openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
-        onView(withText(R.string.settings)).check(matches(isDisplayed()));
-    }
-
-    /**
-     * Tests that the settings activity is opened when a user clicks the settings menu item from
-     * the security dashboard.
-     */
-    @Test
-    public void clickingSettingsMenuItem__OpensSettingsActivity() {
+    public void clickingHomeButton__ReturnsToSecurityDashboardActivity() {
         openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
         Intents.init();
-
         onView(withText(R.string.settings)).perform(click());
-
         intended(hasComponent(SettingsActivity.class.getName()));
         Intents.release();
+
+        onView(withContentDescription(R.string.abc_action_bar_up_description)).perform(click());
+
+        onView(withText(R.string.app_title)).check(matches(isDisplayed()));
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="InnerclassSeparator"
-    package="com.andela.art">
+    package="com.andela.art"
+    tools:ignore="InnerclassSeparator">
 
     <application
+        android:name=".root.App"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:name=".root.App"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
@@ -22,8 +22,9 @@
         <activity
             android:name=".serialentry.SerialEntryActivity"
             android:label="@string/title_activity_serial_entry"
-            android:theme="@style/AppTheme"></activity>
-        <activity android:name=".securitydashboard.SecurityDashboardActivity"></activity>
+            android:theme="@style/AppTheme" />
+        <activity android:name=".securitydashboard.SecurityDashboardActivity" />
+        <activity android:name=".settings.SettingsActivity"></activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/andela/art/securitydashboard/SecurityDashboardActivity.java
+++ b/app/src/main/java/com/andela/art/securitydashboard/SecurityDashboardActivity.java
@@ -1,11 +1,14 @@
 package com.andela.art.securitydashboard;
 
+import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.view.Menu;
+import android.view.MenuItem;
 
 import com.andela.art.R;
+import com.andela.art.settings.SettingsActivity;
 
 /**
  * This is the security dashboard that provides an interface for the security officers to perform
@@ -28,6 +31,14 @@ public class SecurityDashboardActivity extends AppCompatActivity {
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.main_menu, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        Intent settings = new Intent(SecurityDashboardActivity.this,
+                SettingsActivity.class);
+        startActivity(settings);
         return true;
     }
 }

--- a/app/src/main/java/com/andela/art/settings/SettingsActivity.java
+++ b/app/src/main/java/com/andela/art/settings/SettingsActivity.java
@@ -1,0 +1,36 @@
+package com.andela.art.settings;
+
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.support.v7.widget.Toolbar;
+import android.view.MenuItem;
+
+import com.andela.art.R;
+
+/**
+ * This is activity manages a users settings.
+ */
+public class SettingsActivity extends AppCompatActivity {
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.settings_page);
+
+        Toolbar toolbar = (Toolbar) findViewById(R.id.mToolBar);
+        setSupportActionBar(toolbar);
+
+        ActionBar actionBar = getSupportActionBar();
+        actionBar.setTitle(R.string.settings);
+        actionBar.setDisplayHomeAsUpEnabled(true);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        super.onBackPressed();
+        return true;
+    }
+}

--- a/app/src/main/res/layout/settings_page.xml
+++ b/app/src/main/res/layout/settings_page.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/primaryBalticSea"
+    android:orientation="vertical">
+
+    <include layout="@layout/tool_bar"></include>
+
+
+    <TextView
+        android:id="@+id/tvLogOut"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/avenir_book"
+        android:padding="24dp"
+        android:text="@string/logout"
+        android:textColor="@android:color/white"
+        android:textSize="16sp" />
+
+    <View style="@style/Divider" />
+
+    <TextView
+        android:id="@+id/tvReportProblem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/avenir_book"
+        android:padding="24dp"
+        android:text="@string/report_a_problem"
+        android:textColor="@android:color/white"
+        android:textSize="16sp" />
+
+    <View style="@style/Divider" />
+
+    <TextView
+        android:id="@+id/tvSendFeedback"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/avenir_book"
+        android:padding="24dp"
+        android:text="@string/send_feedback"
+        android:textColor="@android:color/white"
+        android:textSize="16sp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/tool_bar.xml
+++ b/app/src/main/res/layout/tool_bar.xml
@@ -9,6 +9,7 @@
     app:title="@string/app_title"
     app:theme="@style/AppTheme.AppBarOverlay"
     app:titleTextAppearance="@style/AppBarTitle"
+    app:popupTheme="@style/ThemeOverlay.AppBarPopup"
     tools:context="com.andela.art.securitydashboard.SecurityDashboardActivity">
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,4 +14,7 @@
     <string name="navigation_drawer_close">Close navigation drawer</string>
     <string name="app_title">Resource Tracker</string>
     <string name="settings">Settings</string>
+    <string name="logout">Log out</string>
+    <string name="send_feedback">Send feedback</string>
+    <string name="report_a_problem">Report a problem</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -24,11 +24,22 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:background">@color/primaryCharade</item>
+        <item name="android:fontFamily">@font/avenir_book</item>
     </style>
 
     <style name="AppBarTitle" parent="@android:style/TextAppearance">
         <item name="android:textSize">20sp</item>
-        <item name="android:fontFamily">@font/avenir_book</item>
+    </style>
+
+    <style name="ThemeOverlay.AppBarPopup" parent="ThemeOverlay.AppCompat.Light">
+        <item name="android:background">@android:color/white</item>
+        <item name="android:textColorPrimary">@android:color/black</item>
+    </style>
+
+    <style name="Divider">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">1dp</item>
+        <item name="android:background">#6a6f6e</item>
     </style>
 
     <style name="MenuItemsText" parent="@android:style/TextAppearance.Medium">


### PR DESCRIPTION
## What does this PR do?
Adds a settings page
## Description of Task to be completed?
- Add tests to ensure navigate to and from the settings page
- Style settings menu item and create layout for the settings page
- Add logic to show and dismiss the settings page 
## How should this be manually tested?
- Run the SecurityDashboardTest and SettingsTest test files
- Launch the App on a device and login to access the security dashboard. Selecting the settings menu item should directed you to the settings activity. Clicking the home/up button should direct you back to the dashboard.
## What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/156266393
## Screenshot
Settings page
<img width="350" alt="settings_page" src="https://user-images.githubusercontent.com/29823251/37991092-e436b008-3210-11e8-90cf-571d9bb0f138.png">
