### PR TITLE
#156723526 Change min SDK version to 19

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
     flavorDimensions "default"
     defaultConfig {
         applicationId "com.andela.art"
-        minSdkVersion 22
+        minSdkVersion 19
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
#### What does this PR do?
Sets the minimum version of SDK to version 19.

#### Description of Task to be completed?
Modifies the `build.gradle` file to change the `minSdkVersion`  default configuration to 19.

#### How should this be manually tested?
Should run on a device having android Kit Kat.

#### What are the relevant pivotal tracker stories?
[#156723526](https://www.pivotaltracker.com/story/show/156723526)

Screenshots.
N/A
