### PR TITLE
#157103459 Fix app crash when no internet

### DIFF
--- a/app/src/main/java/com/andela/art/login/SecurityEmailsPresenter.java
+++ b/app/src/main/java/com/andela/art/login/SecurityEmailsPresenter.java
@@ -1,5 +1,7 @@
 package com.andela.art.login;
 
+import android.content.Context;
+import android.widget.Toast;
 import com.andela.art.api.ApiService;
 import com.andela.art.root.Constants;
 import com.andela.art.root.Presenter;
@@ -18,14 +20,18 @@ public class SecurityEmailsPresenter implements Presenter<SecurityEmailsView> {
     private final ApiService apiService;
     private SecurityEmailsView securityEmailsView;
     SharedPrefsWrapper sharedPrefsWrapper;
+    private final Context mContext;
 
     /**
      * @param sharedPrefsWrapper  - sharedPrefsWrapper
      * @param apiService - apiService
+     * @param context - context
      */
-    public SecurityEmailsPresenter(SharedPrefsWrapper sharedPrefsWrapper, ApiService apiService) {
+    public SecurityEmailsPresenter(SharedPrefsWrapper sharedPrefsWrapper, ApiService apiService,
+                                   Context context) {
         this.apiService = apiService;
         this.sharedPrefsWrapper = sharedPrefsWrapper;
+        this.mContext = context;
     }
 
     /**
@@ -50,8 +56,9 @@ public class SecurityEmailsPresenter implements Presenter<SecurityEmailsView> {
                     String accessToken = tokenResponse.getAccessToken();
                     sharedPrefsWrapper.putString("OAUTH", accessToken);
                     fetchSecurityUserEmails();
-                });
-
+                }, e -> Toast
+                        .makeText(mContext, "No internet Connection", Toast.LENGTH_SHORT)
+                        .show());
     }
     /**
      * Fetch the emails for a security user.

--- a/app/src/main/java/com/andela/art/login/injection/LoginModule.java
+++ b/app/src/main/java/com/andela/art/login/injection/LoginModule.java
@@ -42,12 +42,13 @@ public class LoginModule {
      * Provide SecurityEmailsPresenter.
      * @param sharedPrefsWrapper  - sharedPrefsWrapper
      * @param apiService - apiService
+     * @param context - context
      * @return SecurityEmailsPresenter object
      */
     @Provides
     public SecurityEmailsPresenter providesSecurityEmailsPresenter(
-            SharedPrefsWrapper sharedPrefsWrapper, ApiService apiService) {
-        return new SecurityEmailsPresenter(sharedPrefsWrapper, apiService);
+            SharedPrefsWrapper sharedPrefsWrapper, ApiService apiService, Context context) {
+        return new SecurityEmailsPresenter(sharedPrefsWrapper, apiService, context);
     }
 
     /**

--- a/app/src/test/java/com/andela/art/login/SecurityEmailsPresenterTest.java
+++ b/app/src/test/java/com/andela/art/login/SecurityEmailsPresenterTest.java
@@ -1,5 +1,7 @@
 package com.andela.art.login;
 
+import android.content.Context;
+
 import com.andela.art.api.ApiService;
 import com.andela.art.api.EmailsResponse;
 import com.andela.art.api.TokenResponse;
@@ -31,6 +33,9 @@ public class SecurityEmailsPresenterTest {
     @Mock
     SharedPrefsWrapper sharedPrefsWrapper;
 
+    @Mock
+    Context context;
+
     SecurityEmailsPresenter securityEmailsPresenter;
 
     EmailsResponse emailsResponse;
@@ -46,7 +51,8 @@ public class SecurityEmailsPresenterTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        securityEmailsPresenter = new SecurityEmailsPresenter(sharedPrefsWrapper, apiService);
+        securityEmailsPresenter = new SecurityEmailsPresenter(
+                sharedPrefsWrapper, apiService, context);
         securityEmailsPresenter.attachView(securityEmailsView);
         emailsResponse = new EmailsResponse();
         tokenResponse = new TokenResponse();


### PR DESCRIPTION
#### What does this PR do?
Solves the crash bug when application is loaded for the first time and there is no internet.

#### Description of Task to be completed?
This PR adds onError method call on the observer that receive data made on the endpoint of login in a user, without this method errors are not being handled hence the crash. Add a toast to notify the user of unavailable internet connection.

#### How should this be manually tested?
The app should not crash on the first instance when there is no internet.

#### What are the relevant pivotal tracker stories?
[#157103459](https://www.pivotaltracker.com/story/show/157103459)

Screenshots.
N/A
