### PR TITLE
Fix User names cut out on the security user dashboard

### DIFF
--- a/app/src/main/res/layout/activity_check_in.xml
+++ b/app/src/main/res/layout/activity_check_in.xml
@@ -31,11 +31,11 @@
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:layout_marginTop="235dp"
+            android:layout_marginTop="212dp"
             android:fontFamily="@font/avenir_heavy"
             android:text="@string/full_name"
             android:textColor="#dadcdf"
-            android:textSize="25sp"
+            android:textSize="23sp"
             android:textStyle="normal" />
 
 


### PR DESCRIPTION
**What does this PR do?**
Fixes an issue where Usernames are cut out on the security user dashboard.

**Description of Task to be completed?**
Fix an issue where Usernames are cut out on the security user dashboard.

**How should this be manually tested?**
Login into the app as a security user and then click the check serial button and enter a serial number. On clicking ok, the username of the item owner should be displayed on the CheckinActivity.

**What are the relevant pivotal tracker stories?**
[#157475599](https://www.pivotaltracker.com/story/show/157475599)

**Screenshots**.
N/A