### PR TITLE
#161229849: Fetch security users emails from the api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 default: &defaults
   docker:
-    - image: gcr.io/andela-learning/circlebuildenv:v4
+    - image: gcr.io/bench-projects/bench-projects/circlebuildenv:v6
       auth:
         username: _json_key
         password: '${SERVICE_ACCOUNT_JSON_KEY}'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,7 +44,7 @@ android {
             buildConfigField "String" ,"BASE_URL", "\"http://localhost:3000\""
         }
         prod {
-            buildConfigField "String" ,"BASE_URL", "\"http://art-backend.herokuapp.com\""
+            buildConfigField "String" ,"BASE_URL", "\"http://api-staging-art.andela.com\""
         }
     }
 

--- a/app/src/main/java/com/andela/art/login/SecurityEmailsPresenter.java
+++ b/app/src/main/java/com/andela/art/login/SecurityEmailsPresenter.java
@@ -62,7 +62,6 @@ public class SecurityEmailsPresenter implements Presenter<SecurityEmailsView> {
     }
     /**
      * Fetch the emails for a security user.
-     * @param
      */
     public void fetchSecurityUserEmails() {
          apiService.getEmails()

--- a/app/src/prod/java/com/andela/art/login/LoginActivity.java
+++ b/app/src/prod/java/com/andela/art/login/LoginActivity.java
@@ -93,6 +93,13 @@ public class LoginActivity extends AppCompatActivity implements SecurityEmailsVi
                     startActivity(intent);
 
                 } else {
+                    while (allowedEmailAddresses.isEmpty()) {
+                        try {
+                            wait(100);
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
+                    }
                         // filter out only specific GMail addresses assigned to the guards
                         if (isAllowedNonAndelaEmail(mAuth.getCurrentUser().getEmail())) {
                             Toast.makeText(this, "Allowed non Andela email",

--- a/app/src/prod/java/com/andela/art/login/LoginActivity.java
+++ b/app/src/prod/java/com/andela/art/login/LoginActivity.java
@@ -234,7 +234,6 @@ public class LoginActivity extends AppCompatActivity implements SecurityEmailsVi
         }
     }
 
-
     /**
      * Check to see if a given non Andela GMail address is among the ones allowed to login.
      *
@@ -255,6 +254,9 @@ public class LoginActivity extends AppCompatActivity implements SecurityEmailsVi
      */
     @Override
     public void populateEmailList(List<String> emails) {
+        if (emails.isEmpty()) {
+            return;
+        }
         allowedEmailAddresses.addAll(emails);
     }
 


### PR DESCRIPTION
#### What does this PR do?
Sets up correct endpoint for getting security users from the backend api.
#### Description of Task to be completed?
- Change base api to the new ` http://api-staging-art.andela.com ` from ` http://andela-learning.com `.
- Make getting the data from api responsive.
#### How should this be manually tested?
- Ensure you have a security account set up with the backend team.
- Open the app.
- Check the verbose logcat on Android studio and find the call made to security emails endpoint. You should find your email there.
- Log in with your security account.
#### What are the relevant pivotal tracker stories?
[#161229849](https://www.pivotaltracker.com/story/show/161229849)
A security user is fetched from the API
#### Questions:
None so far