### PR TITLE
Ch firebase instrumentation tests #157084397

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,22 @@ jobs:
             bash <(curl -s https://codecov.io/bash)
             bash ~/repo/.circleci/notify_slack_fail.sh
 
+  instrumented_test:
+    <<: *defaults 
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "build.gradle" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run: ./gradlew androidDependencies
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: v1-dependencies-{{ checksum "build.gradle" }}
+ 
   deploy_test_build:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,7 +278,11 @@ jobs:
             REPORTS_DIR=$(gsutil ls gs://art-firebase-test-results | tail -1)
             mkdir ~/reports
             gsutil cp -r $REPORTS_DIR ~/reports
-            
+    # Storing instrumented test reports
+      - store_artifacts:
+          path: ~/reports
+          destination: reports
+
   deploy_test_build:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,34 +202,7 @@ jobs:
           path: ~/repo/app/build/reports/tests
           destination: reports
       
-      # Running UI tests
-      - run:
-          name: Running instrumentation tests on apk build
-          command: |
-            echo y | sdkmanager "system-images;android-22;default;armeabi-v7a"
-            echo no | avdmanager create avd --force --name test --abi armeabi-v7a -k "system-images;android-22;default;armeabi-v7a"
-            echo y | emulator -avd test -skin 768x1280 -no-window &
-            circle-android wait-for-boot
-            ./gradlew connectedAndroidTest
-      
-      # Storing UI test reports
-      - store_artifacts:
-          path: ~/repo/app/build/outputs/androidTest-results
-          destination: reports
-      
-      # Sending notification
-      - run:
-          name: Notifying slack channel on succeed
-          when: on_success
-          command: |
-            bash <(curl -s https://codecov.io/bash)
-            bash ~/repo/.circleci/notify_slack.sh
-      - run:
-          name: Notifying slack channel on fail
-          when: on_fail
-          command: |
-            bash <(curl -s https://codecov.io/bash)
-            bash ~/repo/.circleci/notify_slack_fail.sh
+
 
   instrumented_test:
     <<: *defaults 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,8 +236,8 @@ jobs:
           command: |
             gcloud beta firebase test android run \
             --type instrumentation \
-            --app app/build/outputs/apk/debug/app-debug.apk \
-            --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
+            --app app/build/outputs/apk/mock/debug/app-mock-debug.apk \
+            --test app/build/outputs/apk/androidTest/mock/debug/app-mock-debug-androidTest.apk \
             --directories-to-pull=/sdcard/tmp \
             --timeout 20m \
             --results-bucket art-firebase-test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,6 +290,12 @@ jobs:
           command: |
             echo $CIRCLE_ARTIFACTS
             bash .circleci/notify_slack.sh
+      - run:
+          name: Notifying slack channel on fail
+          when: on_fail
+          command: |
+            echo $CIRCLE_ARTIFACTS
+            bash .circleci/notify_slack_fail.sh
 
   deploy_test_build:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ default: &defaults
     - image: gcr.io/bench-projects/bench-projects/circlebuildenv:v6
       auth:
         username: _json_key
-        password: '${SERVICE_ACCOUNT_JSON_KEY}'
+        password: "${SERVICE_ACCOUNT_JSON_KEY}"
 
   working_directory: ~/repo
 
@@ -21,26 +21,26 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "build.gradle" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "build.gradle" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
       - run: ./gradlew androidDependencies
       - save_cache:
           paths:
             - ~/.gradle
           key: v1-dependencies-{{ checksum "build.gradle" }}
-      
+
       # Running static analysis tools
       - run:
           name: Running quality checks
           command: |
             echo "Run android lint"
             ./gradlew lint
-      
+
       # Storing reports
       - store_artifacts:
           path: ~/repo/app/build/reports
-      
+
       # Sending notification
       - run:
           name: Notifying slack channel (succeeded)
@@ -60,15 +60,15 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "build.gradle" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "build.gradle" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
       - run: ./gradlew androidDependencies
       - save_cache:
           paths:
             - ~/.gradle
           key: v1-dependencies-{{ checksum "build.gradle" }}
-      
+
       # Running static analysis tools
       - run:
           name: Running quality checks
@@ -76,11 +76,11 @@ jobs:
             echo "Run findbugs"
             ./gradlew assemble
             ./gradlew findbugs
-      
+
       # Storing reports
       - store_artifacts:
           path: ~/repo/app/build/outputs
-      
+
       # Sending notification
       - run:
           name: Notifying slack channel (succeeded)
@@ -100,26 +100,26 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "build.gradle" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "build.gradle" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
       - run: ./gradlew androidDependencies
       - save_cache:
           paths:
             - ~/.gradle
           key: v1-dependencies-{{ checksum "build.gradle" }}
-      
+
       # Running static analysis tools
       - run:
           name: Running quality checks
           command: |
             echo "Run PMD"
             ./gradlew pmd
-      
+
       # Storing reports
       - store_artifacts:
           path: ~/repo/app/build
-      
+
       # Sending notification
       - run:
           name: Notifying slack channel (succeeded)
@@ -139,26 +139,26 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "build.gradle" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "build.gradle" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
       - run: ./gradlew androidDependencies
       - save_cache:
           paths:
             - ~/.gradle
           key: v1-dependencies-{{ checksum "build.gradle" }}
-      
+
       # Running static analysis tools
       - run:
           name: Running quality checks
           command: |
             echo "Run checkstyle"
             ./gradlew checkstyle
-      
+
       # Storing reports
       - store_artifacts:
           path: ~/repo/app/build/reports
-      
+
       # Sending notification
       - run:
           name: Notifying slack channel (succeeded)
@@ -172,15 +172,15 @@ jobs:
             bash ~/repo/.circleci/notify_slack_fail.sh
 
   test:
-    <<: *defaults 
+    <<: *defaults
     steps:
       - checkout
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "build.gradle" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "build.gradle" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
       - run: ./gradlew androidDependencies
       - save_cache:
           paths:
@@ -193,7 +193,7 @@ jobs:
           command: |
             ./gradlew build jacocoTestReport assembleAndroidTest
             ls -a app/build/outputs/logs
-      
+
       # Storing unit test reports
       - store_artifacts:
           path: ~/repo/app/build/reports/jacoco
@@ -201,38 +201,36 @@ jobs:
       - store_artifacts:
           path: ~/repo/app/build/reports/tests
           destination: reports
-      
-
 
   instrumented_test:
-    <<: *defaults 
+    <<: *defaults
     steps:
       - checkout
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "build.gradle" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "build.gradle" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
       - run: ./gradlew androidDependencies
       - save_cache:
           paths:
             - ~/.gradle
           key: v1-dependencies-{{ checksum "build.gradle" }}
-    # Build apk with instrumented tests
+      # Build apk with instrumented tests
       - run:
           name: Creating an apk file with instrumented tests
           command: |
             ./gradlew build :app:assembleDebug :app:assembleAndroidTest -PdisablePreDex
-    # Set project ID and use the service account
+      # Set project ID and use the service account
       - run:
           name: Set gcloud project ID and authenticate service account
           command: |
             echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
             gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
             gcloud config set project $GCP_PROJECT_ID
-    
-    # Send test apk to firebase
+
+      # Send test apk to firebase
       - run:
           name: Run instrumented tests on firebase
           command: |
@@ -243,7 +241,7 @@ jobs:
             --directories-to-pull=/sdcard/tmp \
             --timeout 20m \
             --results-bucket art-firebase-test-results
-    # Get test reports from the storage bucket
+      # Get test reports from the storage bucket
       - run:
           name: Download test reports from storage bucket
           when: always
@@ -251,12 +249,12 @@ jobs:
             REPORTS_DIR=$(gsutil ls gs://art-firebase-test-results | tail -1)
             mkdir ~/reports
             gsutil cp -r $REPORTS_DIR ~/reports
-    # Storing instrumented test reports
+      # Storing instrumented test reports
       - store_artifacts:
           path: ~/reports
           destination: reports
 
-    # Sending notification
+      # Sending notification
       - run:
           name: Notifying slack channel on succeed
           when: on_success
@@ -277,9 +275,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "build.gradle" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "build.gradle" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
       - run: ./gradlew androidDependencies
       - save_cache:
           paths:
@@ -320,9 +318,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "build.gradle" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "build.gradle" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
       - run: ./gradlew androidDependencies
       - save_cache:
           paths:
@@ -363,9 +361,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "build.gradle" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "build.gradle" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
       - run: ./gradlew androidDependencies
       - save_cache:
           paths:
@@ -413,6 +411,9 @@ workflows:
             - findbugs_lint
             - pmd_lint
             - checkstyle_lint
+      - instrumented_test:
+          requires:
+            - test
       - deploy_test_build:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,11 @@ jobs:
           paths:
             - ~/.gradle
           key: v1-dependencies-{{ checksum "build.gradle" }}
+    # Build apk with instrumented tests
+      - run:
+          name: Creating an apk file with instrumented tests
+          command: |
+            ./gradlew build :app:assembleDebug :app:assembleAndroidTest -PdisablePreDex
  
   deploy_test_build:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,6 +251,14 @@ jobs:
           name: Creating an apk file with instrumented tests
           command: |
             ./gradlew build :app:assembleDebug :app:assembleAndroidTest -PdisablePreDex
+    # Set project ID and use the service account
+      - run:
+          name: Set gcloud project ID and authenticate service account
+          command: |
+            echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
+            gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+            gcloud config set project $GCP_PROJECT_ID
+
  
   deploy_test_build:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,13 +259,11 @@ jobs:
           name: Notifying slack channel on succeed
           when: on_success
           command: |
-            echo $CIRCLE_ARTIFACTS
             bash .circleci/notify_slack.sh
       - run:
           name: Notifying slack channel on fail
           when: on_fail
           command: |
-            echo $CIRCLE_ARTIFACTS
             bash .circleci/notify_slack_fail.sh
 
   deploy_test_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,8 +258,18 @@ jobs:
             echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
             gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
             gcloud config set project $GCP_PROJECT_ID
-
- 
+    
+    # Send test apk to firebase
+      - run:
+          name: Run instrumented tests on firebase
+          command: |
+            gcloud beta firebase test android run \
+            --type instrumentation \
+            --app app/build/outputs/apk/debug/app-debug.apk \
+            --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
+            --directories-to-pull=/sdcard/tmp \
+            --timeout 20m \
+            --results-bucket art-firebase-test-results
   deploy_test_build:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,6 +270,15 @@ jobs:
             --directories-to-pull=/sdcard/tmp \
             --timeout 20m \
             --results-bucket art-firebase-test-results
+    # Get test reports from the storage bucket
+      - run:
+          name: Download test reports from storage bucket
+          when: always
+          command: |
+            REPORTS_DIR=$(gsutil ls gs://art-firebase-test-results | tail -1)
+            mkdir ~/reports
+            gsutil cp -r $REPORTS_DIR ~/reports
+            
   deploy_test_build:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,14 @@ jobs:
           path: ~/reports
           destination: reports
 
+    # Sending notification
+      - run:
+          name: Notifying slack channel on succeed
+          when: on_success
+          command: |
+            echo $CIRCLE_ARTIFACTS
+            bash .circleci/notify_slack.sh
+
   deploy_test_build:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,6 +414,12 @@ workflows:
       - instrumented_test:
           requires:
             - test
+          filters:
+                branches:
+                    only:
+                        - master
+                        - staging
+                        - develop
       - deploy_test_build:
           requires:
             - test

--- a/.circleci/notify_slack.sh
+++ b/.circleci/notify_slack.sh
@@ -56,7 +56,7 @@ declare_env_variables() {
   elif [ "$CIRCLE_JOB" == 'test' ]; then
     MESSAGE_TEXT="Test Phase Passed! :smiley:"
 
-    # Sorting through the artifact urls to get only the unit test and integration test reports
+    # Sorting through the artifact urls to get only the unit test reports
     DEBUG_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
 /g' | grep 'test[A-Za-z0-9]*Debug[A-Za-z0-9]*\/index\.html')"
     RELEASE_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
@@ -65,16 +65,34 @@ declare_env_variables() {
 /g' | grep 'jacoco[A-Za-z0-9]*Debug[A-Za-z0-9]*\/html\/index\.html')"
     JACOCO_RELEASE_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
 /g' | grep 'jacoco[A-Za-z0-9]*Release[A-Za-z0-9]*\/html\/index\.html')"
-    INTEGRATION_TEST_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
-/g' |  grep 'AVD')"
+
     CIRCLE_ARTIFACTS_BUTTON="$(echo \
         "{\"type\": \"button\", \"text\": \"Unit Test Report (Debug)\", \"url\": \"${DEBUG_REPORT}\"}", \
         "{\"type\": \"button\", \"text\": \"Unit Test Report (Release)\", \"url\": \"${RELEASE_REPORT}\"}", \
         "{\"type\": \"button\", \"text\": \"Jacoco Test Report (Debug)\", \"url\": \"${JACOCO_DEBUG_REPORT}\"}", \
         "{\"type\": \"button\", \"text\": \"Jacoco Test Report (Release)\", \"url\": \"${JACOCO_RELEASE_REPORT}\"}", \
-        "{\"type\": \"button\", \"text\": \"Android Virtual Device (AVD) Test Report\", \"url\": \"${INTEGRATION_TEST_REPORT}\"}" \
     )"
 
+  elif [ "$CIRCLE_JOB" == 'instrumented_test' ];  then
+    MESSAGE_TEXT="The Instrumented Tests Passed! :smiley:"
+
+    # Sorting through the artifact urls to get only the instrumentation test reports
+    INSTRUMENTATION_RESULTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'instrumentation.results')"
+    LOGCAT_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'logcat')"
+    TEST_RESULT_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'test_result_1.xml')"
+    TEST_RESULT_VIDEO="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'video.mp4')"
+
+    CIRCLE_ARTIFACTS_BUTTON="$(echo \
+        "{\"type\": \"button\", \"text\": \"Instrumentation Test Report \", \"url\": \"${INSTRUMENTATION_RESULTS}\"}", \
+        "{\"type\": \"button\", \"text\": \"Logcat Test Report \", \"url\": \"${LOGCAT_REPORT}\"}", \
+        "{\"type\": \"button\", \"text\": \"Test Result Report \", \"url\": \"${TEST_RESULT_REPORT}\"}", \
+        "{\"type\": \"button\", \"text\": \"Test Result Video \", \"url\": \"${TEST_RESULT_VIDEO}\"}", \
+    )"
+    
   elif [ "$CIRCLE_JOB" == 'deploy_test_build' ]; then
     # Sorting through the artifact urls to get only the apk files
     CIRCLE_APK_ARTIFACTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\

--- a/.circleci/notify_slack_fail.sh
+++ b/.circleci/notify_slack_fail.sh
@@ -56,7 +56,7 @@ declare_env_variables() {
   elif [ "$CIRCLE_JOB" == 'test' ]; then
     MESSAGE_TEXT="Test Phase Failed! :scream:"
 
-    # Sorting through the artifact urls to get only the unit test and integration test reports
+    # Sorting through the artifact urls to get only the unit test  reports
 
     DEBUG_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
 /g' | grep 'test[A-Za-z0-9]*Debug[A-Za-z0-9]*\/index\.html')"
@@ -66,16 +66,34 @@ declare_env_variables() {
 /g' | grep 'jacoco[A-Za-z0-9]*Debug[A-Za-z0-9]*\/html\/index\.html')"
     JACOCO_RELEASE_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
 /g' | grep 'jacoco[A-Za-z0-9]*Release[A-Za-z0-9]*\/html\/index\.html')"
-    INTEGRATION_TEST_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
-/g' |  grep 'AVD' || true)"
+    
 
     CIRCLE_ARTIFACTS_BUTTON="$(echo \
         "{\"type\": \"button\", \"text\": \"Unit Test Report (Debug)\", \"url\": \"${DEBUG_REPORT}\"}", \
         "{\"type\": \"button\", \"text\": \"Unit Test Report (Release)\", \"url\": \"${RELEASE_REPORT}\"}", \
         "{\"type\": \"button\", \"text\": \"Jacoco Test Report (Debug)\", \"url\": \"${JACOCO_DEBUG_REPORT}\"}", \
         "{\"type\": \"button\", \"text\": \"Jacoco Test Report (Release)\", \"url\": \"${JACOCO_RELEASE_REPORT}\"}", \
-        "{\"type\": \"button\", \"text\": \"Android Virtual Device (AVD) Test Report\", \"url\": \"${INTEGRATION_TEST_REPORT}\"}"
       )"
+
+  elif [ "$CIRCLE_JOB" == 'instrumented_test' ];  then
+    MESSAGE_TEXT="The Instrumented Tests Failed! :skull:"
+
+    # Sorting through the artifact urls to get only the instrumentation test reports
+    INSTRUMENTATION_RESULTS="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'instrumentation.results')"
+    LOGCAT_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'logcat')"
+    TEST_RESULT_REPORT="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'test_result_1.xml')"
+    TEST_RESULT_VIDEO="$(echo $CIRCLE_ARTIFACTS_URL | sed -E -e 's/[[:blank:]]+/\
+/g' |  grep 'video.mp4')"
+
+    CIRCLE_ARTIFACTS_BUTTON="$(echo \
+        "{\"type\": \"button\", \"text\": \"Instrumentation Test Report \", \"url\": \"${INSTRUMENTATION_RESULTS}\"}", \
+        "{\"type\": \"button\", \"text\": \"Logcat Test Report \", \"url\": \"${LOGCAT_REPORT}\"}", \
+        "{\"type\": \"button\", \"text\": \"Test Result Report \", \"url\": \"${TEST_RESULT_REPORT}\"}", \
+        "{\"type\": \"button\", \"text\": \"Test Result Video \", \"url\": \"${TEST_RESULT_VIDEO}\"}", \
+    )"
 
   elif [ "$CIRCLE_JOB" == 'deploy_test_build' ]; then
     MESSAGE_TEXT="Test Build for Deployment Failed! :scream:"


### PR DESCRIPTION
#### What does this PR do?
- Moves  instrumentation tests from *Circle CI Build Server* to *Firebase*. 
- Slashes the time taken to perform instrumentation tests to approx 6 mins (Was 1approx 17mins initially)
- Gives a more  detailed report on instrumentation tests by including: _Test Results_ , _Logs_ , _Test Video_

#### Description of Task to be completed?
- Have the `instrumentation tests performed from Firebase.`
- Store test results on *GCP Storage Bucket*
- Send slack notifications when  tests  fail or pass


#### How should this be manually tested?
- When a push is made on any branch, the test reports are sent to the slack channel `#art-builds` with all the necessary information.
- Any interested party can click on the available buttons to get the indepth test  reports

![image](https://user-images.githubusercontent.com/11542388/49582904-85690480-f967-11e8-8f2d-dda1b27dcf37.png)

#### Any background context you want to provide?
Instrumentation tests run on a device or an emulator. In the background, your app will be installed and then a testing app will also be installed which will control your app, launching it and running UI tests as needed.
Instrumentation tests can be used to test none UI logic as well. They are especially useful when you need to test code that has a dependency on a context.
Reducing the time taken for instrumentation tests improves feedback loop cycle to  developers increasing feedback productivity.

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/157084397
 
