### PR TITLE
Ft serial with no assigned user 163756064

### DIFF
--- a/app/src/main/java/com/andela/art/models/Asset.java
+++ b/app/src/main/java/com/andela/art/models/Asset.java
@@ -30,6 +30,8 @@ public class Asset implements Serializable {
     private String mSerialNumber;
     @SerializedName("asset_type")
     private String mAssetType;
+    @SerializedName("current_status")
+    private String mCurrentStatus;
 
     /**
      * Allocation status getter.
@@ -46,6 +48,15 @@ public class Asset implements Serializable {
     public void setAllocationStatus(String allocationStatus) {
         mAllocationStatus = allocationStatus;
     }
+
+    /**
+     * Current status getter.
+     * @return mCurrentStatus - String
+     */
+    public String getCurrentStatus() {
+        return mCurrentStatus;
+    }
+
 
     /**
      * Assigned to getter.

--- a/app/src/main/java/com/andela/art/securitydashboard/presentation/NfcSecurityDashboardActivity.java
+++ b/app/src/main/java/com/andela/art/securitydashboard/presentation/NfcSecurityDashboardActivity.java
@@ -6,6 +6,7 @@ import android.app.PendingIntent;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.databinding.DataBindingUtil;
+import android.graphics.Color;
 import android.net.Uri;
 import android.nfc.NdefMessage;
 import android.nfc.NdefRecord;
@@ -23,6 +24,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.View;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.andela.art.R;
@@ -30,6 +32,7 @@ import com.andela.art.api.UserAssetResponse;
 import com.andela.art.checkin.CheckInActivity;
 import com.andela.art.databinding.NfcSecurityDashboardBinding;
 import com.andela.art.login.LoginActivity;
+import com.andela.art.models.Asset;
 import com.andela.art.root.ApplicationComponent;
 import com.andela.art.root.ApplicationModule;
 import com.andela.art.root.ArtApplication;
@@ -196,17 +199,29 @@ public class NfcSecurityDashboardActivity extends AppCompatActivity implements N
      */
     public void sendIntent(UserAssetResponse asset) {
         if (asset.getAssets() == null) {
-            toast = Toast.makeText(this, "Asset not assigned.", Toast.LENGTH_SHORT);
+            toast = Toast.makeText(this,
+                    "The asset serial number is not available.", Toast.LENGTH_LONG);
             toast.show();
         } else {
-            Intent checkInIntent = new Intent(NfcSecurityDashboardActivity.this,
-                    CheckInActivity.class);
-            Bundle bundle = new Bundle();
-            bundle.putSerializable("asset", asset.getAssets().get(0));
-            checkInIntent.putExtras(bundle);
-            startActivity(checkInIntent);
+            Asset assetInfo = asset.getAssets().get(0);
+            if (assetInfo.getCurrentStatus().equals("Available")) {
+                showProgressBar(false);
+                toast = Toast.makeText(this,
+                        "The asset serial number is not assigned to any user.", Toast.LENGTH_LONG);
+                View view = toast.getView();
+                view.setBackgroundResource(android.R.drawable.toast_frame);
+                TextView text = view.findViewById(android.R.id.message);
+                text.setBackgroundColor(Color.parseColor("#DCDCDC"));
+                toast.show();
+            } else {
+                Intent checkInIntent = new Intent(NfcSecurityDashboardActivity.this,
+                        CheckInActivity.class);
+                Bundle bundle = new Bundle();
+                bundle.putSerializable("asset", assetInfo);
+                checkInIntent.putExtras(bundle);
+                startActivity(checkInIntent);
+            }
         }
-
     }
 
     @Override

--- a/app/src/main/java/com/andela/art/securitydashboard/presentation/SecurityDashboardActivity.java
+++ b/app/src/main/java/com/andela/art/securitydashboard/presentation/SecurityDashboardActivity.java
@@ -3,6 +3,7 @@ package com.andela.art.securitydashboard.presentation;
 import android.annotation.TargetApi;
 import android.content.Intent;
 import android.databinding.DataBindingUtil;
+import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -14,10 +15,12 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
+import android.widget.TextView;
 import android.widget.Toast;
 import com.andela.art.R;
 import com.andela.art.api.UserAssetResponse;
 import com.andela.art.checkin.CheckInActivity;
+import com.andela.art.models.Asset;
 import com.andela.art.root.ApplicationComponent;
 import com.andela.art.root.ApplicationModule;
 import com.andela.art.root.ArtApplication;
@@ -28,6 +31,7 @@ import com.andela.art.securitydashboard.injection.DaggerSerialEntryComponent;
 import com.andela.art.securitydashboard.injection.SerialEntryModule;
 import com.andela.art.securitydashboard.injection.FirebasePresenterModule;
 import com.squareup.picasso.Picasso;
+
 import javax.inject.Inject;
 
 /**
@@ -126,17 +130,29 @@ public class SecurityDashboardActivity extends BaseMenuActivity implements Seria
      */
     public void sendIntent(UserAssetResponse asset) {
         if (asset.getAssets() == null) {
-            toast = Toast.makeText(this, "Asset not assigned.", Toast.LENGTH_SHORT);
+            toast = Toast.makeText(this,
+                    "The asset serial number is not available.", Toast.LENGTH_LONG);
             toast.show();
         } else {
-            Intent checkInIntent = new Intent(SecurityDashboardActivity.this,
-                    CheckInActivity.class);
-            Bundle bundle = new Bundle();
-            bundle.putSerializable("asset", asset.getAssets().get(0));
-            checkInIntent.putExtras(bundle);
-            startActivity(checkInIntent);
+            Asset assetInfo = asset.getAssets().get(0);
+            if (assetInfo.getCurrentStatus().equals("Available")) {
+                showProgressBar(false);
+                toast = Toast.makeText(this,
+                        "The asset serial number is not assigned to any user.", Toast.LENGTH_LONG);
+                View view = toast.getView();
+                view.setBackgroundResource(android.R.drawable.toast_frame);
+                TextView text = view.findViewById(android.R.id.message);
+                text.setBackgroundColor(Color.parseColor("#DCDCDC"));
+                toast.show();
+            } else {
+                Intent checkInIntent = new Intent(SecurityDashboardActivity.this,
+                        CheckInActivity.class);
+                Bundle bundle = new Bundle();
+                bundle.putSerializable("asset", assetInfo);
+                checkInIntent.putExtras(bundle);
+                startActivity(checkInIntent);
+            }
         }
-
     }
 
     /**


### PR DESCRIPTION
#### What does this PR do?
Show toast when the serial number is not assigned to any user.

#### Description of Task to be completed?
When security user scans an NFC tag or enter a serial number with no assigned user,
Then a toast showing the serial number is not assigned to any user is displayed.

#### How should this be manually tested?
- Set up the app with android studio. 
- Run the application in a device with nfc support.
- Check serial number that is not assigned.

#### What are the relevant pivotal tracker stories?
[#163756064] https://www.pivotaltracker.com/story/show/163756064