### PR TITLE
163756058: Handle nfc tag with no records

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -25,9 +25,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
-    <output url="file://$PROJECT_DIR$/build/classes" />
-  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
   <component name="ProjectType">
     <option name="id" value="Android" />
   </component>

--- a/app/src/main/java/com/andela/art/securitydashboard/presentation/NfcSecurityDashboardActivity.java
+++ b/app/src/main/java/com/andela/art/securitydashboard/presentation/NfcSecurityDashboardActivity.java
@@ -53,6 +53,8 @@ public class NfcSecurityDashboardActivity extends AppCompatActivity implements N
 
     public static final String MIME_TEXT_PLAIN = "text/plain";
 
+    public static final String TAG = "NfcSecurityDashboardAct";
+
     String nfcSerial;
 
     private View mProgressView;
@@ -144,7 +146,7 @@ public class NfcSecurityDashboardActivity extends AppCompatActivity implements N
                 new NdefReaderTask().execute(tag);
 
             } else {
-                Log.d("check", "Wrong mime type: " + type);
+                Log.d(TAG, "Wrong mime type: " + type);
             }
         } else if (NfcAdapter.ACTION_TECH_DISCOVERED.equals(action)) {
             Tag tag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
@@ -186,7 +188,14 @@ public class NfcSecurityDashboardActivity extends AppCompatActivity implements N
      */
     public void onConfirmClicked(String serial) {
         showProgressBar(true);
-        nfcPresenter.getAsset(serial);
+        if (serial.isEmpty()) {
+            showProgressBar(false);
+            toast = Toast.makeText(this.getApplicationContext(), "No records found on Scanned Tag",
+                    Toast.LENGTH_SHORT);
+            toast.show();
+        } else {
+            nfcPresenter.getAsset(serial);
+        }
     }
 
     /**
@@ -313,7 +322,7 @@ public class NfcSecurityDashboardActivity extends AppCompatActivity implements N
         try {
             filters[0].addDataType(MIME_TEXT_PLAIN);
         } catch (IntentFilter.MalformedMimeTypeException e) {
-            Log.e("check", "Check your mime type", e);
+            Log.e(TAG, "Check your mime type", e);
         }
         if (adapter != null) {
             adapter.enableForegroundDispatch(activity, pendingIntent, filters, techList);
@@ -356,7 +365,7 @@ public class NfcSecurityDashboardActivity extends AppCompatActivity implements N
                     try {
                         return readText(ndefRecord);
                     } catch (UnsupportedEncodingException e) {
-                        Log.e("check", "Unsupported Encoding", e);
+                        Log.e(TAG, "Unsupported Encoding", e);
                     }
                 }
             }

--- a/app/src/main/java/com/andela/art/securitydashboard/presentation/SecurityDashboardActivity.java
+++ b/app/src/main/java/com/andela/art/securitydashboard/presentation/SecurityDashboardActivity.java
@@ -15,19 +15,21 @@ import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.widget.Toast;
+
 import com.andela.art.R;
 import com.andela.art.api.UserAssetResponse;
 import com.andela.art.checkin.CheckInActivity;
+import com.andela.art.databinding.SecurityDashboardBinding;
+import com.andela.art.login.LoginActivity;
 import com.andela.art.root.ApplicationComponent;
 import com.andela.art.root.ApplicationModule;
 import com.andela.art.root.ArtApplication;
-import com.andela.art.databinding.SecurityDashboardBinding;
-import com.andela.art.login.LoginActivity;
 import com.andela.art.root.BaseMenuActivity;
 import com.andela.art.securitydashboard.injection.DaggerSerialEntryComponent;
-import com.andela.art.securitydashboard.injection.SerialEntryModule;
 import com.andela.art.securitydashboard.injection.FirebasePresenterModule;
+import com.andela.art.securitydashboard.injection.SerialEntryModule;
 import com.squareup.picasso.Picasso;
+
 import javax.inject.Inject;
 
 /**
@@ -116,7 +118,22 @@ public class SecurityDashboardActivity extends BaseMenuActivity implements Seria
     @Override
     public void onConfirmClicked(String serial, String assetCode) {
         showProgressBar(true);
-        serialPresenter.getAsset(serial);
+        if (serial.isEmpty()) {
+            showNoRecordToast();
+        } else {
+            serialPresenter.getAsset(serial);
+        }
+    }
+
+    /**
+     * Show snackbar when user does not input serial.
+     * //TODO: Use inbuilt checker instead
+     */
+    private void showNoRecordToast() {
+        showProgressBar(false);
+        toast = Toast.makeText(this.getApplicationContext(), "Please insert serial",
+                Toast.LENGTH_SHORT);
+        toast.show();
     }
 
     /**


### PR DESCRIPTION
#### What does this PR do?
- Provides a message to the user in case an nfc tag has no data.
- Stops app from crashing on scanning an empty tag.
#### Description of Task to be completed?
- Create snackbar with info on empty tag scanned.
#### How should this be manually tested?
- Run the app.
- Acquire an nfc tag with no records on it.
- Scan the tag.
#### Any background context you want to provide?
None.
#### What are the relevant pivotal tracker stories?
163756058
[NFC with no serial number](https://www.pivotaltracker.com/story/show/163756058)