### PR TITLE
Bg return a user friendly message when a serial is not found

### DIFF
--- a/app/src/main/java/com/andela/art/securitydashboard/presentation/NfcSecurityDashboardActivity.java
+++ b/app/src/main/java/com/andela/art/securitydashboard/presentation/NfcSecurityDashboardActivity.java
@@ -274,8 +274,8 @@ public class NfcSecurityDashboardActivity extends AppCompatActivity implements N
 
     @Override
     public void displayErrorMessage(Throwable error) {
-        String message = error.getMessage().toString();
-        toast = Toast.makeText(this, message, Toast.LENGTH_LONG);
+        String message = "The asset is not available.";
+        toast = Toast.makeText(this.getApplicationContext(), message, Toast.LENGTH_LONG);
         toast.show();
     }
 

--- a/app/src/main/java/com/andela/art/securitydashboard/presentation/SecurityDashboardActivity.java
+++ b/app/src/main/java/com/andela/art/securitydashboard/presentation/SecurityDashboardActivity.java
@@ -160,7 +160,7 @@ public class SecurityDashboardActivity extends BaseMenuActivity implements Seria
         if (!showProgressBar) {
             showProgressBar(false);
         }
-        toast = Toast.makeText(this, toastString, toastLength);
+        toast = Toast.makeText(this.getApplicationContext(), toastString, toastLength);
         toast.show();
     }
 
@@ -194,7 +194,7 @@ public class SecurityDashboardActivity extends BaseMenuActivity implements Seria
 
     @Override
     public void displayErrorMessage(Throwable error) {
-        String message = error.getMessage().toString();
+        String message = "The asset is not available.";
         handleToast(message, Toast.LENGTH_LONG, false);
     }
 


### PR DESCRIPTION
#### What does this PR do?
Return a user-friendly message when a serial is not found

#### Description of Task to be completed?
Currently, if a non-existing serial is checked, a `HTTP 404 Not Found` toast message is displayed to the user A more friendly message should be returned to the user.

#### How should this be manually tested?
* Set up the app with android studio.
* Run the application in a device with NFC support.
* Check a random serial number.

#### What are the relevant pivotal tracker stories?
[#157773845] https://www.pivotaltracker.com/story/show/157773845