### PR TITLE
Bg fix error when empty serial is supplied

### DIFF
--- a/app/src/main/java/com/andela/art/checkin/CheckInActivity.java
+++ b/app/src/main/java/com/andela/art/checkin/CheckInActivity.java
@@ -18,7 +18,7 @@ import com.andela.art.root.ApplicationComponent;
 import com.andela.art.root.ApplicationModule;
 import com.andela.art.root.ArtApplication;
 import com.andela.art.root.BaseMenuActivity;
-import com.andela.art.securitydashboard.presentation.SecurityDashboardActivity;
+import com.andela.art.securitydashboard.presentation.NfcSecurityDashboardActivity;
 import com.squareup.picasso.Picasso;
 import java.util.Locale;
 import javax.inject.Inject;
@@ -124,7 +124,7 @@ public class CheckInActivity extends BaseMenuActivity implements CheckInView {
     @Override
     public void goToCheckSerial() {
         Intent intent = new Intent(CheckInActivity.this,
-                SecurityDashboardActivity.class);
+                NfcSecurityDashboardActivity.class);
         startActivity(intent);
         finish();
     }

--- a/app/src/main/java/com/andela/art/securitydashboard/presentation/NfcSecurityDashboardActivity.java
+++ b/app/src/main/java/com/andela/art/securitydashboard/presentation/NfcSecurityDashboardActivity.java
@@ -173,7 +173,6 @@ public class NfcSecurityDashboardActivity extends AppCompatActivity implements N
 
         Tag tag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
         new NdefReaderTask(this).execute(tag);
-
     }
 
     /**
@@ -198,7 +197,12 @@ public class NfcSecurityDashboardActivity extends AppCompatActivity implements N
      */
     public void onConfirmClicked(String serial) {
         showProgressBar(true);
-        nfcPresenter.getAsset(serial);
+        if (serial.isEmpty()) {
+            showProgressBar(false);
+            showTagHasNoData();
+        } else {
+            nfcPresenter.getAsset(serial);
+        }
     }
 
     /**
@@ -274,6 +278,7 @@ public class NfcSecurityDashboardActivity extends AppCompatActivity implements N
 
     @Override
     public void displayErrorMessage(Throwable error) {
+        showProgressBar(false);
         String message = "The asset is not available.";
         toast = Toast.makeText(this.getApplicationContext(), message, Toast.LENGTH_LONG);
         toast.show();

--- a/app/src/main/java/com/andela/art/securitydashboard/presentation/SecurityDashboardActivity.java
+++ b/app/src/main/java/com/andela/art/securitydashboard/presentation/SecurityDashboardActivity.java
@@ -160,6 +160,7 @@ public class SecurityDashboardActivity extends BaseMenuActivity implements Seria
         if (!showProgressBar) {
             showProgressBar(false);
         }
+        showProgressBar(false);
         toast = Toast.makeText(this.getApplicationContext(), toastString, toastLength);
         toast.show();
     }

--- a/app/src/main/java/com/andela/art/securitydashboard/presentation/threading/NdefReaderTask.java
+++ b/app/src/main/java/com/andela/art/securitydashboard/presentation/threading/NdefReaderTask.java
@@ -38,16 +38,19 @@ public class NdefReaderTask extends AsyncTask<Tag, Void, String> {
         }
 
         NdefMessage ndefMessage = ndef.getCachedNdefMessage();
-
-        NdefRecord[] records = ndefMessage.getRecords();
-        for (NdefRecord ndefRecord : records) {
-            if (ndefRecord.getTnf() == NdefRecord
-                    .TNF_WELL_KNOWN && Arrays.equals(ndefRecord.getType(),
-                    NdefRecord.RTD_TEXT)) {
-                try {
-                    return readText(ndefRecord);
-                } catch (UnsupportedEncodingException e) {
-                    Log.e(TAG, "Unsupported Encoding", e);
+        if (ndefMessage == null) {
+            return null;
+        } else {
+            NdefRecord[] records = ndefMessage.getRecords();
+            for (NdefRecord ndefRecord : records) {
+                if (ndefRecord.getTnf() == NdefRecord
+                        .TNF_WELL_KNOWN && Arrays.equals(ndefRecord.getType(),
+                        NdefRecord.RTD_TEXT)) {
+                    try {
+                        return readText(ndefRecord);
+                    } catch (UnsupportedEncodingException e) {
+                        Log.e(TAG, "Unsupported Encoding", e);
+                    }
                 }
             }
         }


### PR DESCRIPTION
**What does this PR do?**
Fix errors when empty serial is displayed in both NFC enabled and not enabled devices

**Description of Task to be completed?**
Given an empty asset-serial is supplied
- Remove loader when check-in empty serial
- Show error message when empty NFC tag is supplied
- Display NFC activity after check-in

**How should this be manually tested?**
Set up the app with android studio.
Run the application in a device with NFC support.
Supply an empty serial during check serial or use an empty NFC tag

What are the relevant pivotal tracker stories?
[#164692275] https://www.pivotaltracker.com/story/show/164692275
[#164692468] https://www.pivotaltracker.com/story/show/164692468


