### PR TITLE
Bg fix nfc enabled overkill

### DIFF
--- a/app/src/main/java/com/andela/art/securitydashboard/presentation/NfcSecurityDashboardActivity.java
+++ b/app/src/main/java/com/andela/art/securitydashboard/presentation/NfcSecurityDashboardActivity.java
@@ -105,10 +105,14 @@ public class NfcSecurityDashboardActivity extends AppCompatActivity implements N
             startActivity(intent);
         }
 
-        if (mNfcAdapter != null && !mNfcAdapter.isEnabled()) {
-            Toast.makeText(this, "NFC is disabled.", Toast.LENGTH_LONG).show();
-        } else {
-            Toast.makeText(this, "NFC is enabled.", Toast.LENGTH_LONG).show();
+        if (mNfcAdapter != null) {
+            if (!mNfcAdapter.isEnabled()) {
+                Toast.makeText(this.getApplicationContext(), "NFC is disabled.",
+                        Toast.LENGTH_LONG).show();
+            } else {
+                Toast.makeText(this.getApplicationContext(), "NFC is enabled.",
+                        Toast.LENGTH_LONG).show();
+            }
         }
         isActivityActive = true;
         nfcPresenter.attachVieww(this);

--- a/app/src/main/java/com/andela/art/securitydashboard/presentation/SecurityDashboardActivity.java
+++ b/app/src/main/java/com/andela/art/securitydashboard/presentation/SecurityDashboardActivity.java
@@ -84,16 +84,13 @@ public class SecurityDashboardActivity extends BaseMenuActivity implements Seria
         firebasePresenter.onAuthStateChanged();
 
         mProgressView = findViewById(R.id.asset_details_progress_bar_serial);
-
         Snackbar snackbar = Snackbar.make(securityDashboardBinding.securityDashboardLayout,
-                "This device doesn't support NFC.",
-                Snackbar.LENGTH_INDEFINITE);
+                "This device does not support NFC.", Snackbar.LENGTH_LONG);
         View snackbarView = snackbar.getView();
-        snackbarView.setPadding(10, 10, 10, 12);
+        snackbarView.setPadding(10, 10, 10, 130);
         snackbarView.setBackgroundColor(ContextCompat.getColor(this,
-                R.color.colorAccent));
+                R.color.snackbar_background_color));
         snackbar.show();
-
     }
 
     /**

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <color name="colorPrimary">#3359DF</color>
     <color name="colorPrimaryDark">#0834D0</color>
     <color name="colorAccent">#49AAAF</color>
@@ -14,4 +14,5 @@
     <color name="white">#FFFFFF</color>
     <color name="dialog_tint">#35ccc8</color>
     <color name="dialog_text_view">#262729</color>
+    <color name="snackbar_background_color">#000000</color>
 </resources>

--- a/app/src/prod/java/com/andela/art/login/LoginActivity.java
+++ b/app/src/prod/java/com/andela/art/login/LoginActivity.java
@@ -88,7 +88,6 @@ public class LoginActivity extends AppCompatActivity implements SecurityEmailsVi
                 mConnectionProgressDialog.dismiss();
                 // filter out Andela email addresses
                 if (mAuth.getCurrentUser().getEmail().endsWith("andela.com")) {
-                    Toast.makeText(this, "Andela email", Toast.LENGTH_SHORT).show();
                     Intent intent = new Intent(LoginActivity.this, UserDashBoardActivity.class);
                     startActivity(intent);
 
@@ -101,8 +100,6 @@ public class LoginActivity extends AppCompatActivity implements SecurityEmailsVi
                         };
                         // filter out only specific GMail addresses assigned to the guards
                         if (isAllowedNonAndelaEmail(mAuth.getCurrentUser().getEmail())) {
-                            Toast.makeText(this, "Allowed non Andela email",
-                                    Toast.LENGTH_SHORT).show();
                             Intent intent = new Intent(LoginActivity.this,
                                     NfcSecurityDashboardActivity.class);
                             startActivity(intent);
@@ -145,16 +142,10 @@ public class LoginActivity extends AppCompatActivity implements SecurityEmailsVi
                             public void onComplete() {
                                 // Add check if user is admin here in future
                                 if (andelan) {
-                                    Toast.makeText(LoginActivity.this,
-                                            "Andela email",
-                                            Toast.LENGTH_SHORT).show();
                                     Intent intent = new Intent(LoginActivity.this,
                                             UserDashBoardActivity.class);
                                     startActivity(intent);
                                 } else {
-                                    Toast.makeText(LoginActivity.this,
-                                            "Allowed non Andela email",
-                                            Toast.LENGTH_SHORT).show();
                                     Intent intent = new Intent(LoginActivity.this,
                                             NfcSecurityDashboardActivity.class);
                                     startActivity(intent);


### PR DESCRIPTION
**What does this PR do?**
Display one error when NFC is disabled/enabled

**Description of Task to be completed?**
Display one error when NFC is disabled/enabled.
When NFC is disabled or enabled on an NFC enabled device, the toast message displayed is black text on a black background and is not visible to the user

**How should this be manually tested?**
Set up the app with android studio.
Run the application in a device without NFC support.
Nfc not available snack bar appears

**What are the relevant pivotal tracker stories?**
[#164825770] https://www.pivotaltracker.com/story/show/164825770
[#164825770] https://www.pivotaltracker.com/story/show/164825770