### PR TITLE
Bg fix Security user dashboard launching twice after login

### DIFF
--- a/app/src/main/java/com/andela/art/incidentreport/presentation/IncidentReportActivity.java
+++ b/app/src/main/java/com/andela/art/incidentreport/presentation/IncidentReportActivity.java
@@ -88,7 +88,8 @@ public class IncidentReportActivity extends AppCompatActivity implements Inciden
 
     @Override
     public void showSuccess() {
-       toast =  Toast.makeText(this, "Incident reported successfully", Toast.LENGTH_LONG);
+       toast =  Toast.makeText(getApplicationContext(),
+               "Incident reported successfully", Toast.LENGTH_LONG);
        toast.show();
     }
 

--- a/app/src/prod/java/com/andela/art/login/LoginActivity.java
+++ b/app/src/prod/java/com/andela/art/login/LoginActivity.java
@@ -100,7 +100,6 @@ public class LoginActivity extends AppCompatActivity implements SecurityEmailsVi
                             @Override
                             public void onComplete() {
                                 // Add check if user is admin here in future
-                                //This has been implemented using the mAuthListener in onCreate()
                                 if (andelan) {
                                     Intent intent = new Intent(LoginActivity.this,
                                             UserDashBoardActivity.class);

--- a/app/src/prod/java/com/andela/art/login/LoginActivity.java
+++ b/app/src/prod/java/com/andela/art/login/LoginActivity.java
@@ -83,10 +83,6 @@ public class LoginActivity extends AppCompatActivity implements SecurityEmailsVi
                 .build()
                 .inject(this);
 
-        securityEmailsPresenter.attachView(this);
-        tokenAuthPresenter.attachView(this);
-        securityEmailsPresenter.retrieveOauthToken();
-
         mAuthListener = firebaseAuth -> {
             if (firebaseAuth.getCurrentUser() != null) {
                 mConnectionProgressDialog.dismiss();
@@ -94,31 +90,27 @@ public class LoginActivity extends AppCompatActivity implements SecurityEmailsVi
                 if (mAuth.getCurrentUser().getEmail().endsWith("andela.com")) {
                     Intent intent = new Intent(LoginActivity.this, UserDashBoardActivity.class);
                     startActivity(intent);
-
                 } else {
-                        Thread waitForSecurityEmails = new Thread() {
-                            @Override
-                            public void run() {
-
-                            }
-                        };
-                        // filter out only specific GMail addresses assigned to the guards
-                        if (isAllowedNonAndelaEmail(mAuth.getCurrentUser().getEmail())) {
-                            Intent intent = new Intent(LoginActivity.this,
-                                    NfcSecurityDashboardActivity.class);
-                            startActivity(intent);
-                        } else {
-                            mGoogleSignInClient.signOut();
-                            try {
-                                throw new ApiException(new Status(UNAUTHORIZED_CODE));
-                            } catch (ApiException e) {
-                                e.printStackTrace();
-                            }
+                    // filter out only specific GMail addresses assigned to the guards
+                    if (isAllowedNonAndelaEmail(mAuth.getCurrentUser().getEmail())) {
+                        Intent intent = new Intent(LoginActivity.this,
+                                NfcSecurityDashboardActivity.class);
+                        startActivity(intent);
+                    } else {
+                        mGoogleSignInClient.signOut();
+                        try {
+                            throw new ApiException(new Status(UNAUTHORIZED_CODE));
+                        } catch (ApiException e) {
+                            e.printStackTrace();
                         }
+                    }
                 }
             }
         };
 
+        securityEmailsPresenter.attachView(this);
+        tokenAuthPresenter.attachView(this);
+        securityEmailsPresenter.retrieveOauthToken();
         dashboard = new Intent(LoginActivity.this, NfcSecurityDashboardActivity.class);
         ActivityLoginBinding activityLoginBinding = DataBindingUtil
                 .setContentView(this, R.layout.activity_login);
@@ -148,16 +140,7 @@ public class LoginActivity extends AppCompatActivity implements SecurityEmailsVi
                             @Override
                             public void onComplete() {
                                 // Add check if user is admin here in future
-                                if (andelan) {
-                                    Intent intent = new Intent(LoginActivity.this,
-                                            UserDashBoardActivity.class);
-                                    startActivity(intent);
-                                } else {
-                                    Intent intent = new Intent(LoginActivity.this,
-                                            NfcSecurityDashboardActivity.class);
-                                    startActivity(intent);
-                                }
-
+                                //This has been implemented using the mAuthListener in onCreate()
                             }
 
                             @Override
@@ -206,7 +189,6 @@ public class LoginActivity extends AppCompatActivity implements SecurityEmailsVi
                 if ("andela.com".equals(emailDomain)) {
                     andelan = true;
                     firebasewithGoogleAuth(account);
-
                 } else {
                     // filter out only specific GMail addresses assigned to the guards
                     if (isAllowedNonAndelaEmail(account.getEmail())) {

--- a/app/src/prod/java/com/andela/art/reportproblem/presentation/ReportProblemActivity.java
+++ b/app/src/prod/java/com/andela/art/reportproblem/presentation/ReportProblemActivity.java
@@ -82,7 +82,8 @@ public class ReportProblemActivity extends AppCompatActivity implements ReportPr
         String reportType = "bug";
 
         if (message.isEmpty()) {
-            Toast.makeText(this, "Cannot submit an empty report", Toast.LENGTH_LONG).show();
+            String toastMessage = "Cannot submit an empty report";
+            displayToast(toastMessage);
             return;
         }
 
@@ -96,10 +97,8 @@ public class ReportProblemActivity extends AppCompatActivity implements ReportPr
      * @param reportProblem reportProblem model
      */
     public void reportProblemSuccess(ReportProblem reportProblem) {
-        Toast.makeText(
-                this,
-                "Report submitted successfully",
-                Toast.LENGTH_LONG).show();
+        String toastMessage = "Report submitted successfully";
+        displayToast(toastMessage);
 
         reportProblemPresenter.dispose();
     }
@@ -110,9 +109,19 @@ public class ReportProblemActivity extends AppCompatActivity implements ReportPr
      * @param e throwable exception
      */
     public void reportProblemError(Throwable e) {
+        String toastMessage = "Report not submitted. Please try again";
+        displayToast(toastMessage);
+    }
+
+    /**
+     * Display toast feedback.
+     *
+     * @param message The toast message
+     */
+    public void displayToast(String message) {
         Toast.makeText(
-                this,
-                "Report not submitted. Please try again",
+                getApplicationContext(),
+                message,
                 Toast.LENGTH_LONG).show();
     }
 }

--- a/app/src/prod/java/com/andela/art/sendfeedback/presentation/SendFeedbackActivity.java
+++ b/app/src/prod/java/com/andela/art/sendfeedback/presentation/SendFeedbackActivity.java
@@ -65,7 +65,8 @@ public class SendFeedbackActivity extends AppCompatActivity implements SendFeedb
         String reportType = "feedback";
 
         if (message.isEmpty()) {
-            Toast.makeText(this, "Please provide feedback", Toast.LENGTH_LONG).show();
+            String toastMessage = "Please provide feedback";
+            displayToast(toastMessage);
             return;
         }
 
@@ -78,10 +79,8 @@ public class SendFeedbackActivity extends AppCompatActivity implements SendFeedb
      * @param sendFeedback reportProblem model
      */
     public void sendFeedbackSuccess(SendFeedback sendFeedback) {
-        Toast.makeText(
-                this,
-                "Feedback sent successfully",
-                Toast.LENGTH_LONG).show();
+        String toastMessage = "Feedback sent successfully";
+        displayToast(toastMessage);
 
         sendFeedbackPresenter.dispose();
     }
@@ -92,10 +91,8 @@ public class SendFeedbackActivity extends AppCompatActivity implements SendFeedb
      * @param e throwable exception
      */
     public void sendFeedbackError(Throwable e) {
-        Toast.makeText(
-                this,
-                "Report not submitted. Please try again",
-                Toast.LENGTH_LONG).show();
+        String toastMessage = "Report not submitted. Please try again";
+        displayToast(toastMessage);
     }
 
     /**
@@ -106,5 +103,17 @@ public class SendFeedbackActivity extends AppCompatActivity implements SendFeedb
     public void closeFeedback(View view) {
         super.onBackPressed();
         finish();
+    }
+
+    /**
+     * Display toast feedback.
+     *
+     * @param message The toast message
+     */
+    public void displayToast(String message) {
+        Toast.makeText(
+                getApplicationContext(),
+                message,
+                Toast.LENGTH_LONG).show();
     }
 }


### PR DESCRIPTION
**What does this PR do?**
Fixes the Security user dashboard to launch only once
Fix nonvisible incident report and send feedback toast messages

**Description of Task to be completed?**
When the user logs in, the activity is launched twice, to solve this we remove firebase auth listener from the onCreate method since the onComplete googleAuthLogin listener achieves the same functionality.

**How should this be manually tested?**
Run the app.
Log in as a security user

**What are the relevant pivotal tracker stories?**
https://www.pivotaltracker.com/story/show/164980954