### PR TITLE
162695214: Nfc Security Dashboard Tests

### DIFF
--- a/app/src/androidTest/java/com/andela/art/checkin/CheckInActivityTest.java
+++ b/app/src/androidTest/java/com/andela/art/checkin/CheckInActivityTest.java
@@ -2,6 +2,7 @@ package com.andela.art.checkin;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.IdlingRegistry;
@@ -12,6 +13,7 @@ import com.andela.art.R;
 import com.andela.art.models.Asignee;
 import com.andela.art.models.Asset;
 import com.andela.art.securitydashboard.presentation.SecurityDashboardActivity;
+import com.andela.art.utils.ConditionalIgnoreRule;
 import com.andela.art.utils.MockWebServerRule;
 import com.andela.art.utils.RestServiceTestHelper;
 import com.andela.art.utils.WaitActivityIsResumedIdlingResource;
@@ -91,6 +93,9 @@ public class CheckInActivityTest {
     @Rule
     public MockWebServerRule mockWebServerRule = new MockWebServerRule();
 
+    @Rule
+    public ConditionalIgnoreRule rule = new ConditionalIgnoreRule();
+
     /**
      * Test details fed from intent is displayed.
      */
@@ -126,6 +131,7 @@ public class CheckInActivityTest {
      * @throws Exception - exception
      */
     @Test
+    @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnDevice.class)
     public void testClickCheckOut() throws Exception {
         String fileName = "check-in-asset.json";
         String fileName2 = "asset_response.json";
@@ -178,5 +184,18 @@ public class CheckInActivityTest {
      */
     @After
     public void tearDown() {
+    }
+
+    /**
+     * Condition that should cause a test to be ignored.
+     */
+    public class RunningOnDevice implements ConditionalIgnoreRule.IgnoreCondition {
+        /**
+         * Return boolean if condition is satisfied or not.
+         * @return boolean
+         */
+        public boolean isSatisfied() {
+            return !Build.PRODUCT.startsWith("sdk_google");
+        }
     }
 }

--- a/app/src/androidTest/java/com/andela/art/securitydashboard/SecurityDashboardActivityTest.java
+++ b/app/src/androidTest/java/com/andela/art/securitydashboard/SecurityDashboardActivityTest.java
@@ -1,5 +1,6 @@
 package com.andela.art.securitydashboard;
 
+import android.os.Build;
 import android.support.test.espresso.IdlingRegistry;
 import android.support.test.espresso.IdlingResource;
 import android.support.test.espresso.intent.matcher.BundleMatchers;
@@ -11,6 +12,7 @@ import android.widget.Toast;
 import com.andela.art.R;
 import com.andela.art.checkin.CheckInActivity;
 import com.andela.art.securitydashboard.presentation.SecurityDashboardActivity;
+import com.andela.art.utils.ConditionalIgnoreRule;
 import com.andela.art.utils.MockWebServerRule;
 import com.andela.art.utils.OkHttpIdlingResourceRule;
 import com.andela.art.utils.RestServiceTestHelper;
@@ -69,11 +71,15 @@ public class SecurityDashboardActivityTest {
     @Rule
     public MockWebServerRule mockWebServerRule = new MockWebServerRule();
 
+    @Rule
+    public ConditionalIgnoreRule rule = new ConditionalIgnoreRule();
+
     /**
      * Test dialog box.
      * @throws IOException if an error occurs
      */
     @Test
+    @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnDevice.class)
     public void testDialogBoxAppearsWhenButtonClicked() throws IOException {
         activityTestRule.launchActivity(null);
         onView(withId(R.id.addSerial))
@@ -86,6 +92,7 @@ public class SecurityDashboardActivityTest {
      * @throws Exception if an error occurs
      */
     @Test
+    @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnDevice.class)
     public void testAssetDataIsRetrievedWhenCorrectSerialIsEntered() throws Exception {
         String fileName = "asset_response.json";
         String asset = RestServiceTestHelper.
@@ -111,6 +118,7 @@ public class SecurityDashboardActivityTest {
      * @throws Exception if an error occurs
      */
     @Test
+    @ConditionalIgnoreRule.ConditionalIgnore(condition = RunningOnDevice.class)
     public void testUnassignedAssetDisplaysUnassignedToast() throws Exception {
         String fileName = "null_asset_response.json";
         String nullAsset = RestServiceTestHelper.
@@ -180,6 +188,19 @@ public class SecurityDashboardActivityTest {
         Toast toast = activityTestRule.getActivity().toast;
         if (toast != null) {
             toast.cancel();
+        }
+    }
+
+    /**
+     * Condition that should cause a test to be ignored.
+     */
+    public class RunningOnDevice implements ConditionalIgnoreRule.IgnoreCondition {
+        /**
+         * Return boolean if condition is satisfied or not.
+         * @return boolean
+         */
+        public boolean isSatisfied() {
+            return !Build.PRODUCT.startsWith("sdk_google");
         }
     }
 }

--- a/app/src/androidTest/java/com/andela/art/utils/ConditionalIgnoreRule.java
+++ b/app/src/androidTest/java/com/andela/art/utils/ConditionalIgnoreRule.java
@@ -1,0 +1,174 @@
+package com.andela.art.utils;
+
+import org.junit.Assume;
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Modifier;
+
+/**
+ * Created by Kalela on 02/04/2019.
+ */
+public class ConditionalIgnoreRule implements MethodRule {
+    /**
+     * Condition interface.
+     */
+    public interface IgnoreCondition {
+        /**
+         * Is condition satisfied.
+         * @return boolean.
+         */
+        boolean isSatisfied();
+    }
+
+    /**
+     * Conditional ignore annotation retained in runtime.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.METHOD})
+    public @interface ConditionalIgnore {
+        /**
+         *
+         * @return condition.
+         */
+        Class<? extends IgnoreCondition> condition();
+    }
+
+    @Override
+    public Statement apply(Statement base, FrameworkMethod method, Object target) {
+        Statement result = base;
+        if (hasConditionalIgnoreAnnotation(method)) {
+            IgnoreCondition condition = getIgnoreContition(target, method);
+            if (condition.isSatisfied()) {
+                result = new IgnoreStatement(condition);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Check if test has a conditional ignore annotation.
+     * @param method method
+     * @return boolean
+     */
+    private static boolean hasConditionalIgnoreAnnotation(FrameworkMethod method) {
+        return method.getAnnotation(ConditionalIgnore.class) != null;
+    }
+
+    /**
+     * Get the ignore condition.
+     * @param target target
+     * @param method method
+     * @return the condition.
+     */
+    private static IgnoreCondition getIgnoreContition(Object target, FrameworkMethod method) {
+        ConditionalIgnore annotation = method.getAnnotation(ConditionalIgnore.class);
+        return new IgnoreConditionCreator(target, annotation).create();
+    }
+
+    /**
+     * Created by Kalela on 02/04/2019.
+     */
+    private static class IgnoreConditionCreator {
+        private final Object target;
+        private final Class<? extends IgnoreCondition> conditionType;
+
+        /**
+         * constructor.
+         * @param target target
+         * @param annotation annotation
+         */
+        IgnoreConditionCreator(Object target, ConditionalIgnore annotation) {
+            this.target = target;
+            this.conditionType = annotation.condition();
+        }
+
+        /**
+         *
+         * @return condition
+         */
+        IgnoreCondition create() {
+            checkConditionType();
+            try {
+                return createCondition();
+            } catch (RuntimeException re) {
+                throw re;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        /**
+         *
+         * @return condition
+         * @throws Exception exception
+         */
+        private IgnoreCondition createCondition() throws Exception {
+            IgnoreCondition result;
+            if (isConditionTypeStandalone()) {
+                result = conditionType.newInstance();
+            } else {
+                result = conditionType.getDeclaredConstructor(target.getClass())
+                        .newInstance(target);
+            }
+            return result;
+        }
+
+        /**
+         * Check condition type.
+         */
+        private void checkConditionType() {
+            if (!isConditionTypeStandalone() && !isConditionTypeDeclaredInTarget()) {
+                String msg
+                        = "Conditional class '%s' is a member class "
+                        + "but was not declared inside the test case using it.\n"
+                        + "Either make this class a static class, "
+                        + "standalone class (by declaring it in it's own file) "
+                        + "or move it inside the test case using it";
+                throw new IllegalArgumentException(String.format(msg, conditionType.getName()));
+            }
+        }
+
+        /**
+         *
+         * @return boolean
+         */
+        private boolean isConditionTypeStandalone() {
+            return !conditionType.isMemberClass() || Modifier
+                    .isStatic(conditionType.getModifiers());
+        }
+
+        /**
+         *
+         * @return boolean
+         */
+        private boolean isConditionTypeDeclaredInTarget() {
+            return target.getClass().isAssignableFrom(conditionType.getDeclaringClass());
+        }
+    }
+
+    /**
+     * Created by Kalela on 02/04/2019.
+     */
+    private static class IgnoreStatement extends Statement {
+        private final IgnoreCondition condition;
+
+        /**
+         * constructor.
+         * @param condition condition
+         */
+        IgnoreStatement(IgnoreCondition condition) {
+            this.condition = condition;
+        }
+
+        @Override
+        public void evaluate() {
+            Assume.assumeTrue("Ignored by " + condition.getClass().getSimpleName(), true);
+        }
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
Ensures instrumentation tests pass on both real device and emulator environment.
#### Description of Task to be completed?
- Set up a ConditionalIgnore test rule.
- Use the rule to conditionally ignore some tests when running on device.
#### How should this be manually tested?
- Run the tests on an NFC enabled device.
- See how many tests are ignored.
- Run the tests on an emulator and note how many tests are ignored.
#### Any background context you want to provide?
The NFC security dashboard activity has no tests written for it. It is however opened in place of the Serial security dashboard activity in devices that support nfc technology(all real devices as of now). This causes the tests to fail in scenarios where they are run on these physical devices. This PR seeks to solve this issue by running different tests on different device configurations.

#### What are the relevant pivotal tracker stories?
#162695214
https://www.pivotaltracker.com/story/show/162695214
