### PR TITLE
165143553: Add toolbar menu option to NfcDashboardActivity

### DIFF
--- a/app/src/main/java/com/andela/art/checkin/CheckInActivity.java
+++ b/app/src/main/java/com/andela/art/checkin/CheckInActivity.java
@@ -6,6 +6,9 @@ import android.databinding.DataBindingUtil;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.view.Menu;
 import android.view.View;
 import android.widget.Toast;
 
@@ -20,7 +23,6 @@ import com.andela.art.room.CheckInRepository;
 import com.andela.art.root.ApplicationComponent;
 import com.andela.art.root.ApplicationModule;
 import com.andela.art.root.ArtApplication;
-import com.andela.art.root.BaseMenuActivity;
 import com.andela.art.securitydashboard.presentation.NfcSecurityDashboardActivity;
 import com.squareup.picasso.Picasso;
 import java.util.Locale;
@@ -30,7 +32,7 @@ import javax.inject.Inject;
  * Created by zack on 3/26/18.
  */
 
-public class CheckInActivity extends BaseMenuActivity implements CheckInView {
+public class CheckInActivity extends AppCompatActivity implements CheckInView {
     ActivityCheckInBinding binding;
     @Inject
     CheckInPresenter presenter;
@@ -41,6 +43,10 @@ public class CheckInActivity extends BaseMenuActivity implements CheckInView {
     private View mProgressView;
     private CheckInRepository mRepository;
 
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        return false;
+    }
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -170,6 +176,7 @@ public class CheckInActivity extends BaseMenuActivity implements CheckInView {
         } else {
             status = "Checkin";
         }
+        Log.d("memememe", "callCheckin: " + id);
         presenter.checkIn(id, status);
         saveCheckIn(id, status);
     }

--- a/app/src/main/java/com/andela/art/securitydashboard/presentation/NfcSecurityDashboardActivity.java
+++ b/app/src/main/java/com/andela/art/securitydashboard/presentation/NfcSecurityDashboardActivity.java
@@ -16,7 +16,6 @@ import android.os.Handler;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.FragmentManager;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.View;
@@ -31,6 +30,7 @@ import com.andela.art.models.Asset;
 import com.andela.art.root.ApplicationComponent;
 import com.andela.art.root.ApplicationModule;
 import com.andela.art.root.ArtApplication;
+import com.andela.art.root.BaseMenuActivity;
 import com.andela.art.securitydashboard.injection.DaggerSerialEntryComponent;
 import com.andela.art.securitydashboard.injection.FirebasePresenterModule;
 import com.andela.art.securitydashboard.injection.SerialEntryModule;
@@ -43,7 +43,7 @@ import javax.inject.Inject;
  * Display Dialog box to show asset details from nfc and retrieve further details of asset.
  */
 
-public class NfcSecurityDashboardActivity extends AppCompatActivity implements NfcView {
+public class NfcSecurityDashboardActivity extends BaseMenuActivity implements NfcView {
 
     private NfcAdapter mNfcAdapter;
 
@@ -82,7 +82,7 @@ public class NfcSecurityDashboardActivity extends AppCompatActivity implements N
         nfcSecurityDashboardBinding = DataBindingUtil.setContentView(this,
                 R.layout.nfc_security_dashboard);
 
-        setSupportActionBar((Toolbar) nfcSecurityDashboardBinding.mToolBar);
+        setSupportActionBar((Toolbar) nfcSecurityDashboardBinding.nfcToolBar);
         ApplicationComponent applicationComponent = ((ArtApplication) getApplication())
                 .applicationComponent();
         mNfcAdapter = NfcAdapter.getDefaultAdapter(this);

--- a/app/src/main/res/layout/nfc_security_dashboard.xml
+++ b/app/src/main/res/layout/nfc_security_dashboard.xml
@@ -8,7 +8,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/primaryBalticSea"
-        tools:context="com.andela.art.securitydashboard.presentation.SecurityDashboardActivity">
+        tools:context="com.andela.art.securitydashboard.presentation.NfcSecurityDashboardActivity">
 
         <android.support.constraint.ConstraintLayout
             android:id="@+id/asset_details_progress_bar"
@@ -38,7 +38,7 @@
         </android.support.constraint.ConstraintLayout>
 
         <include
-            android:id="@+id/mToolBar"
+            android:id="@+id/nfcToolBar"
             layout="@layout/tool_bar" />
 
         <de.hdodenhof.circleimageview.CircleImageView


### PR DESCRIPTION
#### What does this PR do?
Adds menu options to NfcDashboardActivity and removes them in the Checkin/CheckoutActivity.
#### Description of Task to be completed?
- Inherit BaseMenuActivity into NfcDashboardActivity.
- Override menu display on Checkin/CheckoutActivity.
#### How should this be manually tested?
- Run the app on an NFC enabled device.
- Log in as a security user.
- Use the toolbar menu to logout.
#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
#165143553
https://www.pivotaltracker.com/story/show/165143553