### PR TITLE
Feat display card when no assets assigned to user

### DIFF
--- a/app/src/main/java/com/andela/art/securitydashboard/presentation/NfcSecurityDashboardActivity.java
+++ b/app/src/main/java/com/andela/art/securitydashboard/presentation/NfcSecurityDashboardActivity.java
@@ -282,7 +282,7 @@ public class NfcSecurityDashboardActivity extends AppCompatActivity implements N
     @Override
     public void displayErrorMessage(Throwable error) {
         showProgressBar(false);
-        String message = "The asset is not available.";
+        String message = "Asset retrieval unsuccessful.";
         nfcSecurityDashboardBinding.scanNfcTitleTextView
                 .setVisibility(View.VISIBLE);
         toast = Toast.makeText(this.getApplicationContext(), message, Toast.LENGTH_LONG);

--- a/app/src/main/java/com/andela/art/securitydashboard/presentation/SecurityDashboardActivity.java
+++ b/app/src/main/java/com/andela/art/securitydashboard/presentation/SecurityDashboardActivity.java
@@ -191,7 +191,7 @@ public class SecurityDashboardActivity extends BaseMenuActivity implements Seria
 
     @Override
     public void displayErrorMessage(Throwable error) {
-        String message = "The asset is not available.";
+        String message = "Asset retrieval unsuccessful.";
         handleToast(message, Toast.LENGTH_LONG, false);
     }
 

--- a/app/src/main/java/com/andela/art/userdashboard/presentation/UserDashBoardActivity.java
+++ b/app/src/main/java/com/andela/art/userdashboard/presentation/UserDashBoardActivity.java
@@ -174,16 +174,9 @@ public class UserDashBoardActivity extends BaseMenuActivity implements SliderVie
     public void onGetAssets(UserAssetResponse response) {
         List<Asset> assets = response.getAssets();
         if (assets.isEmpty()) {
-            List<Asset> asset = new ArrayList();
-            Asset newAsset = new Asset();
-            newAsset.setSerialNumber("NO ASSET ASSIGNED YET");
-            asset.add(newAsset);
-            pagerAdapter = new PagerAdapter(fragmentManager, asset);
-            binding.pager.setAdapter(pagerAdapter);
-            binding.tabDots.setupWithViewPager(binding.pager, true);
+            onEmptyAsset();
             return;
         }
-
         pagerAdapter = new PagerAdapter(fragmentManager, assets);
         binding.pager.setAdapter(pagerAdapter);
         binding.tabDots.setupWithViewPager(binding.pager, true);
@@ -202,5 +195,16 @@ public class UserDashBoardActivity extends BaseMenuActivity implements SliderVie
         }
     }
 
-
+    /**
+     * called when user is not assigned any asset.
+     */
+    public void onEmptyAsset() {
+        List<Asset> asset = new ArrayList();
+        Asset newAsset = new Asset();
+        newAsset.setSerialNumber("NO ASSET ASSIGNED YET");
+        asset.add(newAsset);
+        pagerAdapter = new PagerAdapter(fragmentManager, asset);
+        binding.pager.setAdapter(pagerAdapter);
+        binding.tabDots.setupWithViewPager(binding.pager, true);
+    }
 }

--- a/app/src/main/java/com/andela/art/userdashboard/presentation/UserDashBoardActivity.java
+++ b/app/src/main/java/com/andela/art/userdashboard/presentation/UserDashBoardActivity.java
@@ -26,6 +26,7 @@ import com.andela.art.userdashboard.injection.UserDashBoardModule;
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
 import com.google.firebase.auth.FirebaseUser;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -172,6 +173,17 @@ public class UserDashBoardActivity extends BaseMenuActivity implements SliderVie
     @Override
     public void onGetAssets(UserAssetResponse response) {
         List<Asset> assets = response.getAssets();
+        if (assets.isEmpty()) {
+            List<Asset> asset = new ArrayList();
+            Asset newAsset = new Asset();
+            newAsset.setSerialNumber("NO ASSET ASSIGNED YET");
+            asset.add(newAsset);
+            pagerAdapter = new PagerAdapter(fragmentManager, asset);
+            binding.pager.setAdapter(pagerAdapter);
+            binding.tabDots.setupWithViewPager(binding.pager, true);
+            return;
+        }
+
         pagerAdapter = new PagerAdapter(fragmentManager, assets);
         binding.pager.setAdapter(pagerAdapter);
         binding.tabDots.setupWithViewPager(binding.pager, true);


### PR DESCRIPTION
**What does this PR do?**
Display a message to show an Andelan user that has no asset assigned to them.
Fix asset not available toast

Description of Task to be completed?
- Scenario: No assets assigned 
Given an andelan
When I log into the app using my andela email
Then I should see an `I have no assets` card
If I currently don't have assets assigned to me

- When you submit a serial (on check serial) when assets are not fetched from the backend, you should get **_asset retrieval unsuccessful_** error message.


**How should this be manually tested?**
Run the app.
Log in with andela email that has no asset assigned

**What are the relevant pivotal tracker stories?**
https://www.pivotaltracker.com/story/show/165082788
https://www.pivotaltracker.com/story/show/165148415