### PR TITLE
Feat swipe to refresh allocated assets fragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,9 +49,9 @@ android {
             buildConfigField "String" ,"BASE_URL", "\"http://localhost:3000\""
         }
         prod {
+            // Should switch to art-backend in production
             buildConfigField "String" ,"BASE_URL", "\"http://api-staging-art.andela.com\""
 //            buildConfigField "String" ,"BASE_URL", "\"https://art-backend.herokuapp.com\""
-// Should switch to art-backend in production
         }
     }
 

--- a/app/src/main/java/com/andela/art/checkin/CheckInActivity.java
+++ b/app/src/main/java/com/andela/art/checkin/CheckInActivity.java
@@ -7,7 +7,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
 import android.view.Menu;
 import android.view.View;
 import android.widget.Toast;
@@ -141,6 +140,18 @@ public class CheckInActivity extends AppCompatActivity implements CheckInView {
     }
 
     /**
+     * show user when an error occurs.
+     * @param logType - The current log status
+     */
+    @Override
+    public void displayError(String logType) {
+        showProgressBar(false);
+        Toast.makeText(getApplicationContext(),
+                logType + " failed, please try again.",
+                Toast.LENGTH_LONG).show();
+    }
+
+    /**
      * Shows the progress bar.
      * @param show Boolean to show progressbar.
      */
@@ -176,9 +187,8 @@ public class CheckInActivity extends AppCompatActivity implements CheckInView {
         } else {
             status = "Checkin";
         }
-        Log.d("memememe", "callCheckin: " + id);
         presenter.checkIn(id, status);
-        saveCheckIn(id, status);
+//        saveCheckIn(id, status);
     }
 
     /**
@@ -188,15 +198,13 @@ public class CheckInActivity extends AppCompatActivity implements CheckInView {
      * @param logType - check in status
      */
     public void saveCheckIn(Integer id, String logType) {
+        //Implement to only add data to the database when there is no network
+
         CheckInEntity checkInEntity = new CheckInEntity();
         checkInEntity.setSerialNumber(id);
         checkInEntity.setLogStatus(logType);
 
         mRepository = new CheckInRepository(getApplication());
         mRepository.insert(checkInEntity);
-
-        Toast.makeText(getApplicationContext(),
-                "CheckIn data added to the database successfully",
-                Toast.LENGTH_SHORT).show();
     }
 }

--- a/app/src/main/java/com/andela/art/checkin/CheckInPresenter.java
+++ b/app/src/main/java/com/andela/art/checkin/CheckInPresenter.java
@@ -1,5 +1,6 @@
 package com.andela.art.checkin;
 
+
 import com.andela.art.api.ApiService;
 import com.andela.art.models.CheckInModel;
 
@@ -40,7 +41,7 @@ public class CheckInPresenter {
 
                     @Override
                     public void onError(Throwable e) {
-                        // Run this in case of errors.
+                        view.displayError(logType);
                     }
 
                     @Override

--- a/app/src/main/java/com/andela/art/checkin/CheckInView.java
+++ b/app/src/main/java/com/andela/art/checkin/CheckInView.java
@@ -28,4 +28,10 @@ public interface CheckInView {
      * Get back to security dashboard activity.
      */
     void goToCheckSerial();
+
+    /**
+     * show user when an error occurs.
+     * @param logType - The current log status
+     */
+    void displayError(String logType);
 }

--- a/app/src/main/java/com/andela/art/userdashboard/presentation/AssetSliderFragment.java
+++ b/app/src/main/java/com/andela/art/userdashboard/presentation/AssetSliderFragment.java
@@ -56,8 +56,15 @@ public class AssetSliderFragment extends Fragment {
             binding.assetType.setText(getArguments().getString("type"));
             binding.serial.setText(getArguments().getString("serial"));
             binding.tag.setText(getArguments().getString("tag"));
-        } else {
-            binding.serial.setText(R.string.unassigned);
+
+            if (getArguments().getString("serial").
+                    equals(getResources().getString(R.string.unassigned))) {
+                //setTextAlignment and setGravity not responding hence setPadding
+                binding.serial.setPadding(200, 0, 0, 0);
+                binding.serial.setTextSize(16);
+                binding.asset.setVisibility(View.GONE);
+                binding.mac.setVisibility(View.GONE);
+            }
         }
     }
 }

--- a/app/src/main/java/com/andela/art/userdashboard/presentation/UserDashBoardActivity.java
+++ b/app/src/main/java/com/andela/art/userdashboard/presentation/UserDashBoardActivity.java
@@ -235,10 +235,10 @@ public class UserDashBoardActivity extends BaseMenuActivity implements SliderVie
     public void dismissDialog(String fetchStatus) {
         if (mSwipeRefreshLayout.isRefreshing()) {
             if ("200".equalsIgnoreCase(fetchStatus)) {
-                Toast.makeText(getApplicationContext(), "Assets updated successfully.",
-                        Toast.LENGTH_LONG).show();
                 mSwipeRefreshLayout.setRefreshing(false);
             } else {
+                Toast.makeText(getApplicationContext(), "Updating assets failed.",
+                        Toast.LENGTH_LONG).show();
                 mSwipeRefreshLayout.setRefreshing(false);
             }
         }

--- a/app/src/main/java/com/andela/art/userdashboard/presentation/UserDashBoardActivity.java
+++ b/app/src/main/java/com/andela/art/userdashboard/presentation/UserDashBoardActivity.java
@@ -224,6 +224,7 @@ public class UserDashBoardActivity extends BaseMenuActivity implements SliderVie
         binding.pager.setAdapter(pagerAdapter);
         binding.tabDots.setupWithViewPager(binding.pager, true);
 
+        binding.incidentButton.setVisibility(View.GONE);
         dismissDialog("200");
     }
 

--- a/app/src/main/res/layout/fragment_activity.xml
+++ b/app/src/main/res/layout/fragment_activity.xml
@@ -2,63 +2,70 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <RelativeLayout
+    <android.support.v4.widget.SwipeRefreshLayout
+        android:id="@+id/swipeToRefresh"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="#1E1D23"
-        android:orientation="vertical">
+        android:layout_height="wrap_content">
 
-        <android.support.v7.widget.Toolbar
-            android:id="@+id/userdashboard_in_toolbar"
+        <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="65dp"
-            android:background="#25252f"
-            android:paddingStart="37dp"
-            app:popupTheme="@style/ThemeOverlay.AppBarPopup"
-            app:theme="@style/AppTheme.AppBarOverlay"
-            app:titleTextAppearance="@style/AppBarTitle" />
+            android:layout_height="match_parent"
+            android:background="#1E1D23"
+            android:orientation="vertical">
 
-        <FrameLayout
-            android:id="@+id/profile_container"
-            android:layout_width="match_parent"
-            android:layout_height="250dp"
-            android:layout_below="@+id/userdashboard_in_toolbar" />
-
-        <FrameLayout
-            android:id="@+id/slider_container"
-            android:layout_width="match_parent"
-            android:layout_height="148dp"
-            android:layout_below="@+id/profile_container">
-
-            <android.support.v4.view.ViewPager
-                android:id="@+id/pager"
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/userdashboard_in_toolbar"
                 android:layout_width="match_parent"
-                android:layout_height="180dp" />
-        </FrameLayout>
+                android:layout_height="65dp"
+                android:background="#25252f"
+                android:paddingStart="37dp"
+                app:popupTheme="@style/ThemeOverlay.AppBarPopup"
+                app:theme="@style/AppTheme.AppBarOverlay"
+                app:titleTextAppearance="@style/AppBarTitle" />
 
-        <android.support.design.widget.TabLayout
-            android:id="@+id/tabDots"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:tabBackground="@drawable/tab_selector"
-            app:tabGravity="center"
-            app:tabIndicatorHeight="0dp"
-            android:layout_below="@+id/slider_container"
+            <FrameLayout
+                android:id="@+id/profile_container"
+                android:layout_width="match_parent"
+                android:layout_height="250dp"
+                android:layout_below="@+id/userdashboard_in_toolbar" />
 
-            />
+            <FrameLayout
+                android:id="@+id/slider_container"
+                android:layout_width="match_parent"
+                android:layout_height="148dp"
+                android:layout_below="@+id/profile_container">
 
-        <Button
-            android:id="@+id/incident_button"
-            android:layout_width="183dp"
-            android:layout_height="40dp"
-            android:layout_below="@+id/tabDots"
-            android:layout_centerHorizontal="true"
-            android:visibility="invisible"
-            android:background="@drawable/incident_button"
-            android:fontFamily="@font/avenir_book"
-            android:text="@string/report_damage_loss"
-            android:textColor="@android:color/white" />
+                <android.support.v4.view.ViewPager
+                    android:id="@+id/pager"
+                    android:layout_width="match_parent"
+                    android:layout_height="180dp" />
+            </FrameLayout>
 
-    </RelativeLayout>
+            <android.support.design.widget.TabLayout
+                android:id="@+id/tabDots"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:tabBackground="@drawable/tab_selector"
+                app:tabGravity="center"
+                app:tabIndicatorHeight="0dp"
+                android:layout_below="@+id/slider_container"
+
+                />
+
+            <Button
+                android:id="@+id/incident_button"
+                android:layout_width="183dp"
+                android:layout_height="40dp"
+                android:layout_below="@+id/tabDots"
+                android:layout_centerHorizontal="true"
+                android:visibility="invisible"
+                android:background="@drawable/incident_button"
+                android:fontFamily="@font/avenir_book"
+                android:text="@string/report_damage_loss"
+                android:textColor="@android:color/white" />
+
+        </RelativeLayout>
+
+    </android.support.v4.widget.SwipeRefreshLayout>
 </layout>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,4 +15,7 @@
     <color name="dialog_tint">#35ccc8</color>
     <color name="dialog_text_view">#262729</color>
     <color name="snackbar_background_color">#000000</color>
+    <color name="orange">#FF9900</color>
+    <color name="green">#009900</color>
+    <color name="blue">#000099</color>
 </resources>


### PR DESCRIPTION
**What does this PR do?**
- Adds SwipeToRefresh functionality to reload assets assigned to a user.
- Center aligns _NO ASSET ASSIGNED YET_ message.
- Informs user when checkin/checkout fails.

**Description of Task to be completed?**
Scenario: Reload  assigned assets screen
Given an andelan who has logged in
When I reload the assigned screen
Then I should see an up to date list of the assets assigned to me.

**How should this be manually tested?**
1. Run the app.
2. Log in with andela email that has no asset assigned
3. Assign an asset to the user online
4. Swipe screen to refresh asset list

**What are the relevant pivotal tracker stories?**
https://www.pivotaltracker.com/story/show/165176500
https://www.pivotaltracker.com/story/show/165373008